### PR TITLE
RFR: Automate sort stakeholder groups

### DIFF
--- a/cypress/integration/tests/controls/stakeholdergroups/sort.test.ts
+++ b/cypress/integration/tests/controls/stakeholdergroups/sort.test.ts
@@ -1,0 +1,100 @@
+/// <reference types="cypress" />
+
+import {
+    login,
+    clickByText,
+    sortAsc,
+    sortDesc,
+    verifySortAsc,
+    verifySortDesc,
+    getTableColumnData,
+} from "../../../../utils/utils";
+import { navMenu, navTab } from "../../../views/menu.view";
+import { controls, stakeholdergroups, name, members } from "../../../types/constants";
+
+import { Stakeholdergroups } from "../../../models/stakeholdergroups";
+
+import * as data from "../../../../utils/data_utils";
+
+var stakeholdergroupsList: Array<Stakeholdergroups> = [];
+var stakeholderGroupNames: Array<string> = [];
+
+describe("Stakeholder sort validations", function () {
+    before("Login and Create Test Data", function () {
+        // Perform login
+        login();
+
+        // Create multiple stakeholder groups
+        for (let i = 0; i < 2; i++) {
+            // Create new stakeholder group
+            const stakeholdergroup = new Stakeholdergroups(
+                data.getCompanyName(),
+                data.getDescription()
+            );
+            stakeholdergroup.create();
+            stakeholdergroupsList.push(stakeholdergroup);
+            stakeholderGroupNames.push(stakeholdergroup.name);
+        }
+    });
+
+    beforeEach("Persist session", function () {
+        // Save the session and token cookie for maintaining one login session
+        Cypress.Cookies.preserveOnce("AUTH_SESSION_ID", "KEYCLOAK_SESSION");
+
+        // Interceptors
+        cy.intercept("GET", "/api/controls/stakeholder-group*").as("getStakeholdergroups");
+    });
+
+    after("Perform test data clean up", function () {
+        // Delete the stakeholder groups created before the tests
+        stakeholdergroupsList.forEach(function (stakeholdergroup) {
+            stakeholdergroup.delete();
+        });
+    });
+
+    it("Name sort validations", function () {
+        // Navigate to stakeholder tab
+        clickByText(navMenu, controls);
+        clickByText(navTab, stakeholdergroups);
+        cy.wait("@getStakeholdergroups");
+
+        // Sort the stakeholder groups by name in ascending order
+        sortAsc(name);
+        cy.wait(2000);
+
+        // Verify that the stakeholder group rows are displayed in ascending order
+        const afterAscSortList = getTableColumnData(name);
+        verifySortAsc(afterAscSortList);
+
+        // Sort the stakeholder groups by name in descending order
+        sortDesc(name);
+        cy.wait(2000);
+
+        // Verify that the stakeholder groups rows are displayed in descending order
+        const afterDescSortList = getTableColumnData(name);
+        verifySortDesc(afterDescSortList);
+    });
+
+    it("Member(s) sort validations", function () {
+        // Navigate to stakeholder groups tab
+        clickByText(navMenu, controls);
+        clickByText(navTab, stakeholdergroups);
+        cy.wait("@getStakeholdergroups");
+
+        // Sort the stakeholder groups by members in ascending order
+        sortAsc(members);
+        cy.wait(2000);
+
+        // Verify that the stakeholder groups rows are displayed in ascending order
+        const afterAscSortList = getTableColumnData(members);
+        verifySortAsc(afterAscSortList);
+
+        // Sort the stakeholder groups by members in descending order
+        sortDesc(members);
+        cy.wait(2000);
+
+        // Verify that the stakeholder groups rows are displayed in descending order
+        const afterDescSortList = getTableColumnData(members);
+        verifySortDesc(afterDescSortList);
+    });
+});

--- a/cypress/integration/tests/controls/stakeholdergroups/sort.test.ts
+++ b/cypress/integration/tests/controls/stakeholdergroups/sort.test.ts
@@ -11,7 +11,7 @@ import {
 } from "../../../../utils/utils";
 import * as data from "../../../../utils/data_utils";
 import { navMenu, navTab } from "../../../views/menu.view";
-import { controls, stakeholdergroups, name, members } from "../../../types/constants";
+import { controls, stakeholdergroups, name, memberCount } from "../../../types/constants";
 import { Stakeholdergroups } from "../../../models/stakeholdergroups";
 import { Stakeholders } from "../../../models/stakeholders";
 
@@ -92,19 +92,19 @@ describe("Stakeholder groups sort validations", function () {
         cy.wait("@getStakeholdergroups");
 
         // Sort the stakeholder groups by members in ascending order
-        sortAsc(members);
+        sortAsc(memberCount);
         cy.wait(2000);
 
         // Verify that the stakeholder groups table rows are displayed in ascending order
-        const afterAscSortList = getTableColumnData(members);
+        const afterAscSortList = getTableColumnData(memberCount);
         verifySortAsc(afterAscSortList);
 
         // Sort the stakeholder groups by members in descending order
-        sortDesc(members);
+        sortDesc(memberCount);
         cy.wait(2000);
 
         // Verify that the stakeholder groups table rows are displayed in descending order
-        const afterDescSortList = getTableColumnData(members);
+        const afterDescSortList = getTableColumnData(memberCount);
         verifySortDesc(afterDescSortList);
     });
 });

--- a/cypress/integration/tests/controls/stakeholdergroups/sort.test.ts
+++ b/cypress/integration/tests/controls/stakeholdergroups/sort.test.ts
@@ -9,31 +9,37 @@ import {
     verifySortDesc,
     getTableColumnData,
 } from "../../../../utils/utils";
+import * as data from "../../../../utils/data_utils";
 import { navMenu, navTab } from "../../../views/menu.view";
 import { controls, stakeholdergroups, name, members } from "../../../types/constants";
-
 import { Stakeholdergroups } from "../../../models/stakeholdergroups";
-
-import * as data from "../../../../utils/data_utils";
+import { Stakeholders } from "../../../models/stakeholders";
 
 var stakeholdergroupsList: Array<Stakeholdergroups> = [];
-var stakeholderGroupNames: Array<string> = [];
+var stakeholdersList: Array<Stakeholders> = [];
+var stakeholderNames: Array<string> = [];
 
-describe("Stakeholder sort validations", function () {
+describe("Stakeholder groups sort validations", function () {
     before("Login and Create Test Data", function () {
         // Perform login
         login();
 
-        // Create multiple stakeholder groups
-        for (let i = 0; i < 2; i++) {
+        // Create multiple stakeholder groups and stakeholders
+        for (let i = 0; i < 3; i++) {
+            // Create new stakeholder
+            const stakeholder = new Stakeholders(data.getEmail(), data.getFullName());
+            stakeholder.create();
+            stakeholdersList.push(stakeholder);
+            stakeholderNames.push(stakeholder.name);
+
             // Create new stakeholder group
             const stakeholdergroup = new Stakeholdergroups(
                 data.getCompanyName(),
-                data.getDescription()
+                data.getDescription(),
+                stakeholderNames
             );
             stakeholdergroup.create();
             stakeholdergroupsList.push(stakeholdergroup);
-            stakeholderGroupNames.push(stakeholdergroup.name);
         }
     });
 
@@ -46,14 +52,18 @@ describe("Stakeholder sort validations", function () {
     });
 
     after("Perform test data clean up", function () {
-        // Delete the stakeholder groups created before the tests
+        // Delete the stakeholder groups and stakeholders created before the tests
         stakeholdergroupsList.forEach(function (stakeholdergroup) {
             stakeholdergroup.delete();
+        });
+
+        stakeholdersList.forEach(function (stakeholder) {
+            stakeholder.delete();
         });
     });
 
     it("Name sort validations", function () {
-        // Navigate to stakeholder tab
+        // Navigate to stakeholder groups tab
         clickByText(navMenu, controls);
         clickByText(navTab, stakeholdergroups);
         cy.wait("@getStakeholdergroups");
@@ -62,7 +72,7 @@ describe("Stakeholder sort validations", function () {
         sortAsc(name);
         cy.wait(2000);
 
-        // Verify that the stakeholder group rows are displayed in ascending order
+        // Verify that the stakeholder groups table rows are displayed in ascending order
         const afterAscSortList = getTableColumnData(name);
         verifySortAsc(afterAscSortList);
 
@@ -70,7 +80,7 @@ describe("Stakeholder sort validations", function () {
         sortDesc(name);
         cy.wait(2000);
 
-        // Verify that the stakeholder groups rows are displayed in descending order
+        // Verify that the stakeholder groups table rows are displayed in descending order
         const afterDescSortList = getTableColumnData(name);
         verifySortDesc(afterDescSortList);
     });
@@ -85,7 +95,7 @@ describe("Stakeholder sort validations", function () {
         sortAsc(members);
         cy.wait(2000);
 
-        // Verify that the stakeholder groups rows are displayed in ascending order
+        // Verify that the stakeholder groups table rows are displayed in ascending order
         const afterAscSortList = getTableColumnData(members);
         verifySortAsc(afterAscSortList);
 
@@ -93,7 +103,7 @@ describe("Stakeholder sort validations", function () {
         sortDesc(members);
         cy.wait(2000);
 
-        // Verify that the stakeholder groups rows are displayed in descending order
+        // Verify that the stakeholder groups table rows are displayed in descending order
         const afterDescSortList = getTableColumnData(members);
         verifySortDesc(afterDescSortList);
     });

--- a/cypress/integration/types/constants.ts
+++ b/cypress/integration/types/constants.ts
@@ -14,7 +14,6 @@ export const jobfunctions = "Job functions";
 export const jobfunction = "Job function";
 export const memberCount = "Member count";
 export const name = "Name";
-export const members = "Member(s)";
 export const stakeholders = "Stakeholders";
 export const stakeholdergroups = "Stakeholder groups";
 export const tagCount = "Tag count";

--- a/cypress/integration/types/constants.ts
+++ b/cypress/integration/types/constants.ts
@@ -14,6 +14,7 @@ export const jobfunctions = "Job functions";
 export const jobfunction = "Job function";
 export const memberCount = "Member count";
 export const name = "Name";
+export const members = "Member(s)";
 export const stakeholders = "Stakeholders";
 export const stakeholdergroups = "Stakeholder groups";
 export const tagCount = "Tag count";


### PR DESCRIPTION
This PR contains:


1. Automate stakeholder groups table sort test case
 - Sort by name
 - Sort by member(s)
