### PR TITLE
[RFR] Fixed the edit and delete to accomodate new changes in the UI

### DIFF
--- a/cypress/integration/models/businessservices.ts
+++ b/cypress/integration/models/businessservices.ts
@@ -88,6 +88,7 @@ export class BusinessServices {
         cy.wait(2000);
         cy.get(tdTag)
             .contains(this.name)
+            .parent(tdTag)
             .parent(trTag)
             .within(() => {
                 click(commonView.editButton);
@@ -120,6 +121,7 @@ export class BusinessServices {
         cy.wait(2000);
         cy.get(tdTag)
             .contains(this.name)
+            .parent(tdTag)
             .parent(trTag)
             .within(() => {
                 click(commonView.deleteButton);

--- a/cypress/integration/models/jobfunctions.ts
+++ b/cypress/integration/models/jobfunctions.ts
@@ -40,6 +40,7 @@ export class Jobfunctions {
         cy.wait(2000);
         cy.get(tdTag)
             .contains(this.name)
+            .parent(tdTag)
             .parent(trTag)
             .within(() => {
                 click(commonView.editButton);
@@ -61,6 +62,7 @@ export class Jobfunctions {
         cy.wait(2000);
         cy.get(tdTag)
             .contains(this.name)
+            .parent(tdTag)
             .parent(trTag)
             .within(() => {
                 click(commonView.deleteButton);

--- a/cypress/integration/models/stakeholdergroups.ts
+++ b/cypress/integration/models/stakeholdergroups.ts
@@ -86,6 +86,7 @@ export class Stakeholdergroups {
         cy.wait(2000);
         cy.get(tdTag)
             .contains(this.name)
+            .parent(tdTag)
             .parent(trTag)
             .within(() => {
                 click(commonView.editButton);
@@ -115,6 +116,7 @@ export class Stakeholdergroups {
         cy.wait(2000);
         cy.get(tdTag)
             .contains(this.name)
+            .parent(tdTag)
             .parent(trTag)
             .within(() => {
                 click(commonView.deleteButton);


### PR DESCRIPTION
Due to new changes in UI, every row element has been wrapped in a span, this was causing the tests to nest deeper and not able to search their parent tr tag.

Updated below delete and edit functions for -

- Stakeholder groups
- Job functions
- Business Services

NOTE : Stakeholder does not require change as the email field in UI is unaltered and it is working fine.