### PR TITLE
RFR: Fixed stakeholder group CRUD test case

### DIFF
--- a/cypress/integration/tests/controls/stakeholdergroups/crud.test.ts
+++ b/cypress/integration/tests/controls/stakeholdergroups/crud.test.ts
@@ -68,6 +68,7 @@ describe("Stakeholder group CRUD operations", () => {
         cy.wait(2000);
         cy.get(tdTag)
             .contains(stakeholdergroup.name)
+            .parent(tdTag)
             .parent(trTag)
             .within(() => {
                 click(expandRow);
@@ -88,6 +89,7 @@ describe("Stakeholder group CRUD operations", () => {
         cy.wait(2000);
         cy.get(tdTag)
             .contains(stakeholdergroup.name)
+            .parent(tdTag)
             .parent(trTag)
             .within(() => {
                 click(expandRow);


### PR DESCRIPTION
Signed-off-by: Ganesh Hubale <ghubale@redhat.com>

Fixed Error:
```
Timed out retrying after 4000ms: Expected to find element: tr, but never found it. Queried from element: <span.pf-m-truncate.pf-c-table__text>

cypress/integration/tests/controls/stakeholdergroups/crud.test.tsat line71

  69 |         cy.get(tdTag)
  70 |             .contains(stakeholdergroup.name)
> 71 |             .parent(trTag)
     |              ^
  72 |             .within(() => {
  73 |                 click(expandRow);
  74 |
```