### PR TITLE
RFR: Fix stakeholder group test cases

### DIFF
--- a/cypress/integration/tests/applicationinventory/application/create.test.ts
+++ b/cypress/integration/tests/applicationinventory/application/create.test.ts
@@ -86,8 +86,6 @@ describe("Application validations", () => {
     });
 
     it("Application unique constraint validation", function () {
-        // Fixed - https://issues.redhat.com/browse/TACKLE-179
-
         const application = new ApplicationInventory(data.getFullName());
 
         // Create a new application

--- a/cypress/integration/tests/applicationinventory/application/create.test.ts
+++ b/cypress/integration/tests/applicationinventory/application/create.test.ts
@@ -85,8 +85,8 @@ describe("Application validations", () => {
         cy.contains(button, createNewButton).should("exist");
     });
 
-    it.skip("Application unique constraint validation", function () {
-        // Run this test after fix - https://issues.redhat.com/browse/TACKLE-179
+    it("Application unique constraint validation", function () {
+        // Fixed - https://issues.redhat.com/browse/TACKLE-179
 
         const application = new ApplicationInventory(data.getFullName());
 

--- a/cypress/integration/tests/controls/stakeholdergroups/filter.test.ts
+++ b/cypress/integration/tests/controls/stakeholdergroups/filter.test.ts
@@ -12,7 +12,6 @@ import {
 import { navMenu, navTab } from "../../../views/menu.view";
 import {
     controls,
-    stakeholders,
     stakeholdergroups,
     button,
     tdTag,
@@ -144,7 +143,7 @@ describe("Stakeholder groups filter validations", function () {
     it("Member filter validations", function () {
         // Navigate to stakeholder groups tab
         clickByText(navMenu, controls);
-        clickByText(navTab, stakeholders);
+        clickByText(navTab, stakeholdergroups);
         cy.wait("@getStakeholdergroups");
 
         // Enter an existing member substring and apply it as search filter

--- a/cypress/integration/tests/controls/stakeholdergroups/filter.test.ts
+++ b/cypress/integration/tests/controls/stakeholdergroups/filter.test.ts
@@ -154,6 +154,7 @@ describe("Stakeholder groups filter validations", function () {
         selectItemsPerPage(100);
         cy.get(tdTag)
             .contains(stakeholdergroupsList[0].name)
+            .parent(tdTag)
             .parent(trTag)
             .within(() => {
                 click(commonView.expandRow);

--- a/cypress/integration/tests/controls/stakeholdergroups/interlinked.test.ts
+++ b/cypress/integration/tests/controls/stakeholdergroups/interlinked.test.ts
@@ -62,6 +62,7 @@ describe("Stakeholder group linked to stakeholder members", () => {
         cy.wait(2000);
         cy.get(tdTag)
             .contains(stakeholdergroup.name)
+            .parent(tdTag)
             .parent(trTag)
             .within(() => {
                 click(expandRow);
@@ -87,6 +88,7 @@ describe("Stakeholder group linked to stakeholder members", () => {
         cy.wait(2000);
         cy.get(tdTag)
             .contains(stakeholdergroup.name)
+            .parent(tdTag)
             .parent(trTag)
             .within(() => {
                 click(expandRow);
@@ -108,6 +110,7 @@ describe("Stakeholder group linked to stakeholder members", () => {
         cy.wait(2000);
         cy.get(tdTag)
             .contains(stakeholdergroup.name)
+            .parent(tdTag)
             .parent(trTag)
             .within(() => {
                 click(expandRow);

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -17,7 +17,7 @@ export function clickByText(fieldId: string, buttonText: string): void {
 }
 
 export function click(fieldId: string): void {
-    cy.get(fieldId).click();
+    cy.get(fieldId).click({ force: true });
 }
 
 export function submitForm(): void {


### PR DESCRIPTION
This PR contains:
- Fix for stakeholder groups interlinked test cases
- Fix for stakeholder groups filter test cases
- Unskipp application unique name constraint test case as issue [179](https://issues.redhat.com/browse/TACKLE-179) fixed.