### PR TITLE
WIP: Fix tagtype/sort.test.ts

### DIFF
--- a/cypress/integration/tests/controls/tags/tagtype/sort.test.ts
+++ b/cypress/integration/tests/controls/tags/tagtype/sort.test.ts
@@ -5,6 +5,7 @@ import {
     clickByText,
     sortAsc,
     sortDesc,
+    verifySort,
     verifySortAsc,
     verifySortDesc,
     getTableColumnData,
@@ -33,7 +34,14 @@ describe("Tag type sort validations", function () {
         cy.wait("@getTagtypes");
 
         // Get unsorted list when page loads
-        const unsortedList = getTableColumnData(tagtype);
+        const expectedAscSortedList = [
+            "application type",
+            "database",
+            "data center",
+            "language",
+            "operating system",
+            "runtime",
+        ];
 
         // Sort the tag type by name in ascending order
         // Issue for sorting corner cases - https://issues.redhat.com/browse/TACKLE-231
@@ -42,7 +50,7 @@ describe("Tag type sort validations", function () {
 
         // Verify that the tag type rows are displayed in ascending order
         const afterAscSortList = getTableColumnData(tagtype);
-        verifySortAsc(afterAscSortList, unsortedList);
+        verifySort(afterAscSortList, expectedAscSortedList);
 
         // Sort the tag type by name in descending order
         sortDesc(tagtype);
@@ -50,7 +58,7 @@ describe("Tag type sort validations", function () {
 
         // Verify that the tag type rows are displayed in descending order
         const afterDescSortList = getTableColumnData(tagtype);
-        verifySortDesc(afterDescSortList, unsortedList);
+        verifySort(afterDescSortList, [...expectedAscSortedList].reverse());
     });
 
     it("Rank sort validations", function () {


### PR DESCRIPTION
Based on the discussion https://issues.redhat.com/browse/TACKLE-231

The current set of "Tag types" are predefined values coming from the backend; those values are: `["Application Type", "Data Center", "Database", "Language", "Operating System", "Runtime"]`

It seems reasonable to me that we can use those values to validate the sorting result of the table "Tag type" so rather than obtaining the expected result from a dynamic sort https://github.com/konveyor/tackle-ui-tests/blob/main/cypress/utils/utils.ts#L186 we can replace it with deterministic values like:

```
const expectedAscSortedList = [
            "application type",
            "database",
            "data center",
            "language",
            "operating system",
            "runtime",
        ];
```

Of course, the `expectedAscSortedList` shouldn't come from our minds but from the execution of a SQL script in a PostgreSQL database:

```
controls_db=# select name from tag_type order by name;
 name 
------------------
 Application Type
 Database
 Data center
 Language
 Operating System
 Runtime
(6 rows)
```

Having said that, I'm aware that this current approach is only valid for the "Tag types" table but not for the other tables like "stakeholder, stakeholder-groups, etc" since those tables are currently populated by the Cypress test code using a lib named "faker".

For the other tables, I wonder if the lib "faker" is able to create random but controlled values like for instance: "stakeholder-a, stakeholder-b, stakeholder-c, stakeholder-d, etc." this way we could remove the edge cases scenarios and the Sorting tests would pass successfully.

@ganeshhubale @nitishSr Please take this PR as a proposal, I'd like to know what is your point of view on this.