### PR TITLE
[RFR] : Sort function modification to be able to work with postgresql sorting

### DIFF
--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -173,9 +173,9 @@ export function getTableColumnData(columnName: string): Array<string> {
                 columnName === memberCount ||
                 columnName === tagCount
             ) {
-                itemList.push(Number($ele.text()));
+                if ($ele.text() !== "") itemList.push(Number($ele.text()));
             } else {
-                itemList.push($ele.text().toString().toLowerCase());
+                if ($ele.text() !== "") itemList.push($ele.text().toString().toLowerCase());
             }
         });
     return itemList;
@@ -183,14 +183,18 @@ export function getTableColumnData(columnName: string): Array<string> {
 
 export function verifySortAsc(listToVerify: Array<any>, unsortedList: Array<any>): void {
     cy.wrap(listToVerify).then((capturedList) => {
-        const sortedList = _.sortBy(unsortedList);
+        var sortedList = unsortedList.sort((a, b) =>
+            a.toString().localeCompare(b, "en-us", { ignorePunctuation: true })
+        );
         expect(capturedList).to.be.deep.equal(sortedList);
     });
 }
 
 export function verifySortDesc(listToVerify: Array<any>, unsortedList: Array<any>): void {
     cy.wrap(listToVerify).then((capturedList) => {
-        const reverseSortedList = _.sortBy(unsortedList).reverse();
+        var reverseSortedList = unsortedList.sort((a, b) =>
+            b.toString().localeCompare(a, "en-us", { ignorePunctuation: true })
+        );
         expect(capturedList).to.be.deep.equal(reverseSortedList);
     });
 }

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -10,6 +10,7 @@ import {
     tdTag,
     trTag,
     button,
+    rank,
 } from "../integration/types/constants";
 import { actionButton } from "../integration/views/applicationinventory.view";
 
@@ -171,7 +172,8 @@ export function getTableColumnData(columnName: string): Array<string> {
             if (
                 columnName === groupCount ||
                 columnName === memberCount ||
-                columnName === tagCount
+                columnName === tagCount ||
+                columnName === rank
             ) {
                 if ($ele.text() !== "") itemList.push(Number($ele.text()));
             } else {
@@ -184,7 +186,10 @@ export function getTableColumnData(columnName: string): Array<string> {
 export function verifySortAsc(listToVerify: Array<any>, unsortedList: Array<any>): void {
     cy.wrap(listToVerify).then((capturedList) => {
         var sortedList = unsortedList.sort((a, b) =>
-            a.toString().localeCompare(b, "en-us", { ignorePunctuation: true })
+            a.toString().localeCompare(b, "en-us", {
+                ignorePunctuation: true,
+                numeric: !unsortedList.some(isNaN),
+            })
         );
         expect(capturedList).to.be.deep.equal(sortedList);
     });
@@ -193,7 +198,10 @@ export function verifySortAsc(listToVerify: Array<any>, unsortedList: Array<any>
 export function verifySortDesc(listToVerify: Array<any>, unsortedList: Array<any>): void {
     cy.wrap(listToVerify).then((capturedList) => {
         var reverseSortedList = unsortedList.sort((a, b) =>
-            b.toString().localeCompare(a, "en-us", { ignorePunctuation: true })
+            b.toString().localeCompare(a, "en-us", {
+                ignorePunctuation: true,
+                numeric: !unsortedList.some(isNaN),
+            })
         );
         expect(capturedList).to.be.deep.equal(reverseSortedList);
     });


### PR DESCRIPTION
After our discussion on the bug - https://issues.redhat.com/browse/TACKLE-231, I agree to the fact that, whatever be the order, it must be consistent as per any one approach, be it database or javascript. Having gone through the comment from Carlos, I understand that, changing database collation and locale, is not best of solution. 
Hence, to keep up with the order Tackle UI is producing, I have modified our test sorting function to be consistent with the result produced by Tackle UI sort.
The other issue, was regarding treatment of empty values, for that, I have just ignored them while doing a sort.
Hope, this solution is satisfactory for all of us. And yeah, it works, having tested it on my local env.
![sort_tests_tagtype_pass](https://user-images.githubusercontent.com/43022982/128475238-786b5e75-f45a-4534-a80b-9449c0b321d4.png)
![sort_by_local_compare](https://user-images.githubusercontent.com/43022982/128475255-0eba2449-3106-4aca-baf5-626e4cce1418.png)


Thanks @carlosthe19916 , I have taken your suggestion for sorting of numeric values with slight modification, and results are as per expectation.

![rank_sort_pass](https://user-images.githubusercontent.com/43022982/128487712-f037dd9b-f96b-41e3-8677-baa1ff4cef1e.png)
