### PR TITLE
RFR: Add manual trigger pull requests

### DIFF
--- a/.github/workflows/prettier.yaml
+++ b/.github/workflows/prettier.yaml
@@ -1,5 +1,5 @@
 name: Code formatting
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -1,5 +1,5 @@
 name: Pull request test
-on: [pull_request]
+on: [pull_request, workflow_dispatch]
 jobs:
   cypress-run:
     if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'RFR')
@@ -24,4 +24,5 @@ jobs:
           echo "::set-output name=tests::$test_files"
           echo "::set-output name=tackleUrl::'https://tackle-ghubale-tackle.apps.mgn02.cnv-qe.rhcloud.com'"
       - name: Run cypress test cases
+        if: ${{ steps.event.outputs.tests }}
         run: npx cypress run --spec ${{ steps.event.outputs.tests }} --env user="tackle",pass="password",tackleUrl=${{ steps.event.outputs.tackleUrl }}

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@
 2. Pull requests will be tested against environment before merging to main codebase
 3. Pull request's owner must add **RFR** label once pull request is ready to test against environment
 4. After adding 'RFR' label; Owner should force push the pull request to trigger GitHub action
+5. In some cases, reviewer wants to trigger the PR test GH action but he/she can't force push the branch. Hence added feature of triggering GH action manually. Steps to trigger GH action for PR testing manually :- Go to Actions tab > Click on GH action(Pull request test) > Click on run workflow dropdown > select PR branch > Click on button Run workflow
 
 #### Test runs
 1. Click here to see **Old** test runs - [run1](https://dashboard.cypress.io/projects/cbdv4m/runs), [run2](https://dashboard.cypress.io/projects/dvmnpr/runs)


### PR DESCRIPTION
Signed-off-by: Ganesh Hubale <ghubale@redhat.com>

- In some cases, reviewer wants to trigger the PR run action but he/she cant force the branch.Hence added feature of trigering github action manually
- After merging this PR. Steps to trigger gh action for PR testing manually - Go to Actions tab > Click on GH action(Pull request test) > Click on run workflow dropdown and select PR branch > Click on button Run workflow