### PR TITLE
RFR: Keep video off after test execution

### DIFF
--- a/.github/workflows/pull-requests.yaml
+++ b/.github/workflows/pull-requests.yaml
@@ -25,4 +25,4 @@ jobs:
           echo "::set-output name=tackleUrl::'https://tackle-ghubale-tackle.apps.mgn02.cnv-qe.rhcloud.com'"
       - name: Run cypress test cases
         if: ${{ steps.event.outputs.tests }}
-        run: npx cypress run --spec ${{ steps.event.outputs.tests }} --env user="tackle",pass="password",tackleUrl=${{ steps.event.outputs.tackleUrl }}
+        run: npx cypress run --spec ${{ steps.event.outputs.tests }} --env user="tackle",pass="password",tackleUrl=${{ steps.event.outputs.tackleUrl }} --config video=false

--- a/reportconfig.json
+++ b/reportconfig.json
@@ -1,6 +1,7 @@
 {
     "viewportWidth": 1280,
     "viewportHeight": 880,
+    "video": false,
     "env": {
         "user": "",
         "pass": "",


### PR DESCRIPTION
Signed-off-by: Ganesh Hubale <ghubale@redhat.com>

- We don't upload videos to report portal.
- Cypress takes video for every test execution which takes too much time to finish on test execution. Hence keeping video off.
- As per current scenario, it will upload screenshot for filed test case
- For PR tester :- We dont need video recording. Hence keeping off.