### PR TITLE
[TACKLE-274]-Fix duplicate assertions in test

### DIFF
--- a/cypress/integration/tests/applicationinventory/application/import.test.ts
+++ b/cypress/integration/tests/applicationinventory/application/import.test.ts
@@ -182,20 +182,20 @@ describe("Application import operations", () => {
         importApplication(filePath + fileName);
         cy.wait(2000);
 
-        // Create object for imported app
-        const importedApp = new ApplicationInventory("Import-app-7");
-        applicationsList.push(importedApp);
 
         // Open application imports page
         openManageImportsPage();
 
         // Verify import applications page shows correct information
-        // Fails due to bug - https://issues.redhat.com/browse/TACKLE-274
-        verifyAppImport(fileName, "Completed", 1, 1);
+        verifyAppImport(fileName, "Completed", 0, 2);
 
         // Verify the error report message
         openErrorReport();
-        verifyImportErrorMsg("Duplicate ApplicationName in table: Import-app-7");
+        const errorMsgs = [
+            "Duplicate Application Name within file: Import-app-7",
+            "Duplicate Application Name within file: Import-app-7",
+        ];
+        verifyImportErrorMsg(errorMsgs);
     });
 
     it("Applications import having description and comments exceeding allowed limits", function () {

--- a/cypress/integration/tests/applicationinventory/application/import.test.ts
+++ b/cypress/integration/tests/applicationinventory/application/import.test.ts
@@ -182,7 +182,6 @@ describe("Application import operations", () => {
         importApplication(filePath + fileName);
         cy.wait(2000);
 
-
         // Open application imports page
         openManageImportsPage();
 


### PR DESCRIPTION
The test `import.test.ts` => `Applications import having same name with spaces` is importing the following CSV:

```
Record Type 1,Application Name,Description,Comments,Business Service,Tag Type 1,Tag 1,Tag Type 2,Tag 2,Tag Type 3,Tag 3,Tag Type 4,Tag 4,Tag Type 5,Tag 5,Tag Type 6,Tag 6,Tag Type 7,Tag 7,Tag Type 8,Tag 8,Tag Type 9,Tag 9,Tag Type 10,Tag 10,Tag Type 11,Tag 11,Tag Type 12,Tag 12,Tag Type 13,Tag 13,Tag Type 14,Tag 14,Tag Type 15,Tag 15,Tag Type 16,Tag 16,Tag Type 17,Tag 17,Tag Type 18,Tag 18,Tag Type 19,Tag 19,Tag Type 20,Tag 20
,Import-app-7,App created using import feature,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,
, Import-app-7 ,Same app created using import feature having trailing and leading whitespace,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,,

```

The CSV above is importing 2 applications `Import-app-7` and `_Import-app-7` the second one with a space at the beginning. Both application's names are equally valid and the same so when we import the CSV none of them should be inserted and a `DUPLICATE` error message should appear.

The current test is expecting to insert the first application and reject the second application but since both are the same both should be rejected.