### PR TITLE
RFR: Add pull request template with instruction to create pull request

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+<!-- Add pull request description here -->
+
+<!--
+
+Instructions while creating pull request.
+ 
+- Add `RFR` label to test pull request test cases
+    - Click on `Labels` > Search `RFR` and select
+- `Request review` from reviewers
+    - sshveta
+    - nitishSr
+    - ganeshhubale
+        - Click on `Reviewers` > Select reviewers from above options
+- `Optional`
+    - Add `RFR` [Ready for review] or `WIP` [Work in progress] as per your pull request progress
+
+-->


### PR DESCRIPTION
Signed-off-by: Ganesh Hubale <ghubale@redhat.com>

From now:

Whenever new PR will be created then PR body will display the instructions to create pull request as below.
It will be hidden and will not appear after creating PR.
```
<!-- Add pull request description here -->

<!--
Instructions while creating pull request.
 
- Add `RFR` label to test pull request test cases
    - Click on `Labels` > Search `RFR` and select
- `Request review` from reviewers
    - sshveta
    - nitishSr
    - ganeshhubale
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] as per your pull request progress
-->
```