### PR TITLE
[RFR] Preserve cookies which contain "Session" keyword

### DIFF
--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -402,9 +402,7 @@ export function deleteApplicationTableRows(): void {
 }
 
 export function preservecookies(): void {
-    cy.getCookies()
-        .should("have.length", 3)
-        .then((cookies) => {
-            Cypress.Cookies.preserveOnce(cookies[0].name, cookies[1].name, cookies[2].name);
-        });
+    Cypress.Cookies.defaults({
+        preserve: /SESSION/,
+    });
 }


### PR DESCRIPTION
Changed logic for preserving all the cookies that contain keyword "SESSION"
As previous logic was relying on fixed number of cookies (3). However, on testing it was found that, cookies vary in number.
