### PR TITLE
[RFR] Added test tagging feature for all the specs

### DIFF
--- a/cypress/integration/models/applicationinventory/applicationinventory.ts
+++ b/cypress/integration/models/applicationinventory/applicationinventory.ts
@@ -231,6 +231,10 @@ export class ApplicationInventory {
             });
     }
 
+    protected performRowAction(buttonName: string): void {
+        cy.get(tdTag).contains(this.name).parent(tdTag).siblings(tdTag).find(buttonName).click();
+    }
+
     create(cancel = false): void {
         ApplicationInventory.clickApplicationInventory();
         clickByText(button, createNewButton);
@@ -271,13 +275,7 @@ export class ApplicationInventory {
         ApplicationInventory.clickApplicationInventory();
         selectItemsPerPage(100);
         cy.wait(2000);
-        cy.get(tdTag)
-            .contains(this.name)
-            .parent(tdTag)
-            .parent(trTag)
-            .within(() => {
-                click(editButton);
-            });
+        this.performRowAction(editButton);
 
         if (cancel) {
             cancelForm();

--- a/cypress/integration/models/applicationinventory/applicationinventory.ts
+++ b/cypress/integration/models/applicationinventory/applicationinventory.ts
@@ -32,6 +32,7 @@ import {
     cancelForm,
     selectFormItems,
     checkSuccessAlert,
+    performRowAction,
 } from "../../../utils/utils";
 import * as data from "../../../utils/data_utils";
 import {
@@ -231,10 +232,6 @@ export class ApplicationInventory {
             });
     }
 
-    protected performRowAction(buttonName: string): void {
-        cy.get(tdTag).contains(this.name).parent(tdTag).siblings(tdTag).find(buttonName).click();
-    }
-
     create(cancel = false): void {
         ApplicationInventory.clickApplicationInventory();
         clickByText(button, createNewButton);
@@ -275,7 +272,7 @@ export class ApplicationInventory {
         ApplicationInventory.clickApplicationInventory();
         selectItemsPerPage(100);
         cy.wait(2000);
-        this.performRowAction(editButton);
+        performRowAction(this.name, editButton);
 
         if (cancel) {
             cancelForm();

--- a/cypress/integration/models/businessservices.ts
+++ b/cypress/integration/models/businessservices.ts
@@ -17,6 +17,7 @@ import {
     cancelForm,
     selectFormItems,
     checkSuccessAlert,
+    performRowAction,
 } from "../../utils/utils";
 
 export class BusinessServices {
@@ -45,10 +46,6 @@ export class BusinessServices {
 
     protected selectOwner(owner: string): void {
         selectFormItems(businessServiceOwnerSelect, owner);
-    }
-
-    protected performRowAction(buttonName: string): void {
-        cy.get(tdTag).contains(this.name).parent(tdTag).siblings(tdTag).find(buttonName).click();
     }
 
     create(cancel = false): void {
@@ -83,7 +80,7 @@ export class BusinessServices {
         BusinessServices.clickBusinessservices();
         selectItemsPerPage(100);
         cy.wait(2000);
-        this.performRowAction(commonView.editButton);
+        performRowAction(this.name, commonView.editButton);
 
         if (cancel) {
             cancelForm();
@@ -110,7 +107,7 @@ export class BusinessServices {
         BusinessServices.clickBusinessservices();
         selectItemsPerPage(100);
         cy.wait(2000);
-        this.performRowAction(commonView.deleteButton);
+        performRowAction(this.name, commonView.deleteButton);
         if (cancel) {
             cancelForm();
         } else {

--- a/cypress/integration/models/businessservices.ts
+++ b/cypress/integration/models/businessservices.ts
@@ -1,11 +1,4 @@
-import {
-    controls,
-    businessservices,
-    tdTag,
-    trTag,
-    button,
-    createNewButton,
-} from "../types/constants";
+import { controls, businessservices, tdTag, button, createNewButton } from "../types/constants";
 import { navMenu, navTab } from "../views/menu.view";
 import {
     businessServiceNameInput,
@@ -54,6 +47,10 @@ export class BusinessServices {
         selectFormItems(businessServiceOwnerSelect, owner);
     }
 
+    protected performRowAction(buttonName: string): void {
+        cy.get(tdTag).contains(this.name).parent(tdTag).siblings(tdTag).find(buttonName).click();
+    }
+
     create(cancel = false): void {
         BusinessServices.clickBusinessservices();
         clickByText(button, createNewButton);
@@ -86,13 +83,7 @@ export class BusinessServices {
         BusinessServices.clickBusinessservices();
         selectItemsPerPage(100);
         cy.wait(2000);
-        cy.get(tdTag)
-            .contains(this.name)
-            .parent(tdTag)
-            .parent(trTag)
-            .within(() => {
-                click(commonView.editButton);
-            });
+        this.performRowAction(commonView.editButton);
 
         if (cancel) {
             cancelForm();
@@ -119,13 +110,7 @@ export class BusinessServices {
         BusinessServices.clickBusinessservices();
         selectItemsPerPage(100);
         cy.wait(2000);
-        cy.get(tdTag)
-            .contains(this.name)
-            .parent(tdTag)
-            .parent(trTag)
-            .within(() => {
-                click(commonView.deleteButton);
-            });
+        this.performRowAction(commonView.deleteButton);
         if (cancel) {
             cancelForm();
         } else {

--- a/cypress/integration/models/jobfunctions.ts
+++ b/cypress/integration/models/jobfunctions.ts
@@ -8,6 +8,7 @@ import {
     selectItemsPerPage,
     submitForm,
     cancelForm,
+    performRowAction,
 } from "../../utils/utils";
 import * as commonView from "../../integration/views/common.view";
 
@@ -27,10 +28,6 @@ export class Jobfunctions {
         inputText(jobfunctionNameInput, name);
     }
 
-    protected performRowAction(buttonName: string): void {
-        cy.get(tdTag).contains(this.name).parent(tdTag).siblings(tdTag).find(buttonName).click();
-    }
-
     create(cancel = false): void {
         Jobfunctions.clickJobfunctions();
         clickByText(button, createNewButton);
@@ -46,7 +43,7 @@ export class Jobfunctions {
         Jobfunctions.clickJobfunctions();
         selectItemsPerPage(100);
         cy.wait(2000);
-        this.performRowAction(commonView.editButton);
+        performRowAction(this.name, commonView.editButton);
 
         if (cancel) {
             cancelForm();
@@ -63,7 +60,7 @@ export class Jobfunctions {
         Jobfunctions.clickJobfunctions();
         selectItemsPerPage(100);
         cy.wait(2000);
-        this.performRowAction(commonView.deleteButton);
+        performRowAction(this.name, commonView.deleteButton);
         if (cancel) {
             cancelForm();
         } else {

--- a/cypress/integration/models/jobfunctions.ts
+++ b/cypress/integration/models/jobfunctions.ts
@@ -1,4 +1,4 @@
-import { controls, jobfunctions, tdTag, trTag, button, createNewButton } from "../types/constants";
+import { controls, jobfunctions, tdTag, button, createNewButton } from "../types/constants";
 import { navMenu, navTab } from "../views/menu.view";
 import { jobfunctionNameInput } from "../views/jobfunctions.view";
 import {
@@ -27,24 +27,27 @@ export class Jobfunctions {
         inputText(jobfunctionNameInput, name);
     }
 
+    protected performRowAction(buttonName: string): void {
+        cy.get(tdTag).contains(this.name).parent(tdTag).siblings(tdTag).find(buttonName).click();
+    }
+
     create(cancel = false): void {
         Jobfunctions.clickJobfunctions();
         clickByText(button, createNewButton);
-        this.fillName(this.name);
-        submitForm();
+        if (cancel) {
+            cancelForm();
+        } else {
+            this.fillName(this.name);
+            submitForm();
+        }
     }
 
     edit(updatedName: string, cancel = false): void {
         Jobfunctions.clickJobfunctions();
         selectItemsPerPage(100);
         cy.wait(2000);
-        cy.get(tdTag)
-            .contains(this.name)
-            .parent(tdTag)
-            .parent(trTag)
-            .within(() => {
-                click(commonView.editButton);
-            });
+        this.performRowAction(commonView.editButton);
+
         if (cancel) {
             cancelForm();
         } else {
@@ -60,13 +63,7 @@ export class Jobfunctions {
         Jobfunctions.clickJobfunctions();
         selectItemsPerPage(100);
         cy.wait(2000);
-        cy.get(tdTag)
-            .contains(this.name)
-            .parent(tdTag)
-            .parent(trTag)
-            .within(() => {
-                click(commonView.deleteButton);
-            });
+        this.performRowAction(commonView.deleteButton);
         if (cancel) {
             cancelForm();
         } else {

--- a/cypress/integration/models/stakeholdergroups.ts
+++ b/cypress/integration/models/stakeholdergroups.ts
@@ -1,11 +1,4 @@
-import {
-    controls,
-    stakeholdergroups,
-    tdTag,
-    trTag,
-    button,
-    createNewButton,
-} from "../types/constants";
+import { controls, stakeholdergroups, tdTag, button, createNewButton } from "../types/constants";
 import { navMenu, navTab } from "../views/menu.view";
 import {
     stakeholdergroupNameInput,
@@ -54,6 +47,10 @@ export class Stakeholdergroups {
         });
     }
 
+    protected performRowAction(buttonName: string): void {
+        cy.get(tdTag).contains(this.name).parent(tdTag).siblings(tdTag).find(buttonName).click();
+    }
+
     create(cancel = false): void {
         Stakeholdergroups.clickStakeholdergroups();
         clickByText(button, createNewButton);
@@ -84,13 +81,7 @@ export class Stakeholdergroups {
         Stakeholdergroups.clickStakeholdergroups();
         selectItemsPerPage(100);
         cy.wait(2000);
-        cy.get(tdTag)
-            .contains(this.name)
-            .parent(tdTag)
-            .parent(trTag)
-            .within(() => {
-                click(commonView.editButton);
-            });
+        this.performRowAction(commonView.editButton);
         if (cancel) {
             cancelForm();
         } else {
@@ -114,13 +105,7 @@ export class Stakeholdergroups {
         Stakeholdergroups.clickStakeholdergroups();
         selectItemsPerPage(100);
         cy.wait(2000);
-        cy.get(tdTag)
-            .contains(this.name)
-            .parent(tdTag)
-            .parent(trTag)
-            .within(() => {
-                click(commonView.deleteButton);
-            });
+        this.performRowAction(commonView.deleteButton);
         if (cancel) {
             cancelForm();
         } else {

--- a/cypress/integration/models/stakeholdergroups.ts
+++ b/cypress/integration/models/stakeholdergroups.ts
@@ -15,6 +15,7 @@ import {
     cancelForm,
     selectFormItems,
     checkSuccessAlert,
+    performRowAction,
 } from "../../utils/utils";
 
 export class Stakeholdergroups {
@@ -47,10 +48,6 @@ export class Stakeholdergroups {
         });
     }
 
-    protected performRowAction(buttonName: string): void {
-        cy.get(tdTag).contains(this.name).parent(tdTag).siblings(tdTag).find(buttonName).click();
-    }
-
     create(cancel = false): void {
         Stakeholdergroups.clickStakeholdergroups();
         clickByText(button, createNewButton);
@@ -81,7 +78,7 @@ export class Stakeholdergroups {
         Stakeholdergroups.clickStakeholdergroups();
         selectItemsPerPage(100);
         cy.wait(2000);
-        this.performRowAction(commonView.editButton);
+        performRowAction(this.name, commonView.editButton);
         if (cancel) {
             cancelForm();
         } else {
@@ -105,7 +102,7 @@ export class Stakeholdergroups {
         Stakeholdergroups.clickStakeholdergroups();
         selectItemsPerPage(100);
         cy.wait(2000);
-        this.performRowAction(commonView.deleteButton);
+        performRowAction(this.name, commonView.deleteButton);
         if (cancel) {
             cancelForm();
         } else {

--- a/cypress/integration/models/stakeholders.ts
+++ b/cypress/integration/models/stakeholders.ts
@@ -16,6 +16,7 @@ import {
     removeMember,
     cancelForm,
     checkSuccessAlert,
+    performRowAction,
 } from "../../utils/utils";
 import * as commonView from "../views/common.view";
 
@@ -61,10 +62,6 @@ export class Stakeholders {
         });
     }
 
-    protected performRowAction(buttonName: string): void {
-        cy.get(tdTag).contains(this.email).siblings(tdTag).find(buttonName).click();
-    }
-
     create(cancel = false): void {
         Stakeholders.clickStakeholders();
         clickByText(button, createNewButton);
@@ -99,7 +96,7 @@ export class Stakeholders {
         Stakeholders.clickStakeholders();
         selectItemsPerPage(100);
         cy.wait(2000);
-        this.performRowAction(commonView.editButton);
+        performRowAction(this.email, commonView.editButton, false);
         if (cancel) {
             cancelForm();
         } else {
@@ -127,7 +124,7 @@ export class Stakeholders {
         Stakeholders.clickStakeholders();
         selectItemsPerPage(100);
         cy.wait(2000);
-        this.performRowAction(commonView.deleteButton);
+        performRowAction(this.email, commonView.deleteButton, false);
         if (cancel) {
             cancelForm();
         } else {

--- a/cypress/integration/models/stakeholders.ts
+++ b/cypress/integration/models/stakeholders.ts
@@ -1,4 +1,4 @@
-import { controls, stakeholders, tdTag, trTag, button, createNewButton } from "../types/constants";
+import { controls, stakeholders, tdTag, button, createNewButton } from "../types/constants";
 import { navMenu, navTab } from "../views/menu.view";
 import {
     stakeholderNameInput,
@@ -61,6 +61,10 @@ export class Stakeholders {
         });
     }
 
+    protected performRowAction(buttonName: string): void {
+        cy.get(tdTag).contains(this.email).siblings(tdTag).find(buttonName).click();
+    }
+
     create(cancel = false): void {
         Stakeholders.clickStakeholders();
         clickByText(button, createNewButton);
@@ -95,12 +99,7 @@ export class Stakeholders {
         Stakeholders.clickStakeholders();
         selectItemsPerPage(100);
         cy.wait(2000);
-        cy.get(tdTag)
-            .contains(this.email)
-            .parent(trTag)
-            .within(() => {
-                click(commonView.editButton);
-            });
+        this.performRowAction(commonView.editButton);
         if (cancel) {
             cancelForm();
         } else {
@@ -128,12 +127,7 @@ export class Stakeholders {
         Stakeholders.clickStakeholders();
         selectItemsPerPage(100);
         cy.wait(2000);
-        cy.get(tdTag)
-            .contains(this.email)
-            .parent(trTag)
-            .within(() => {
-                click(commonView.deleteButton);
-            });
+        this.performRowAction(commonView.deleteButton);
         if (cancel) {
             cancelForm();
         } else {

--- a/cypress/integration/tests/applicationinventory/application/assess_review.test.ts
+++ b/cypress/integration/tests/applicationinventory/application/assess_review.test.ts
@@ -1,6 +1,6 @@
 /// <reference types="cypress" />
 
-import { login, preservecookies } from "../../../../utils/utils";
+import { hasToBeSkipped, login, preservecookies } from "../../../../utils/utils";
 
 import { ApplicationInventory } from "../../../models/applicationinventory/applicationinventory";
 
@@ -10,8 +10,11 @@ import { Stakeholders } from "../../../models/stakeholders";
 var stakeholdersList: Array<Stakeholders> = [];
 var stakeholdersNameList: Array<string> = [];
 
-describe("Application assessment and review tests", () => {
+describe("Application assessment and review tests", { tags: "@tier1" }, () => {
     before("Login and Create Test Data", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier1")) return;
+
         // Perform login
         login();
 

--- a/cypress/integration/tests/applicationinventory/application/create.test.ts
+++ b/cypress/integration/tests/applicationinventory/application/create.test.ts
@@ -7,6 +7,8 @@ import {
     submitForm,
     exists,
     notExists,
+    hasToBeSkipped,
+    preservecookies,
 } from "../../../../utils/utils";
 import { navMenu } from "../../../views/menu.view";
 import {
@@ -27,10 +29,18 @@ import { ApplicationInventory } from "../../../models/applicationinventory/appli
 import * as commonView from "../../../../integration/views/common.view";
 import * as data from "../../../../utils/data_utils";
 
-describe("Application validations", () => {
-    beforeEach("Login", function () {
+describe("Application validations", { tags: "@tier2" }, () => {
+    before("Login", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Perform login
         login();
+    });
+
+    beforeEach("Persist session", function () {
+        // Save the session and token cookie for maintaining one login session
+        preservecookies();
 
         // Interceptors
         cy.intercept("POST", "/api/application-inventory/application*").as("postApplication");

--- a/cypress/integration/tests/applicationinventory/application/crud.test.ts
+++ b/cypress/integration/tests/applicationinventory/application/crud.test.ts
@@ -1,11 +1,14 @@
 /// <reference types="cypress" />
 
-import { exists, login, notExists } from "../../../../utils/utils";
+import { exists, hasToBeSkipped, login, notExists } from "../../../../utils/utils";
 import { ApplicationInventory } from "../../../models/applicationinventory/applicationinventory";
 import * as data from "../../../../utils/data_utils";
 
-describe("Application crud operations", () => {
+describe("Application crud operations", { tags: "@tier1" }, () => {
     beforeEach("Login", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier1")) return;
+
         // Perform login
         login();
 

--- a/cypress/integration/tests/applicationinventory/application/filter.test.ts
+++ b/cypress/integration/tests/applicationinventory/application/filter.test.ts
@@ -6,6 +6,7 @@ import {
     exists,
     preservecookies,
     applySearchFilter,
+    hasToBeSkipped,
 } from "../../../../utils/utils";
 import { navMenu } from "../../../views/menu.view";
 import {
@@ -29,8 +30,12 @@ var businessserviceList: Array<BusinessServices> = [];
 var tagList: Array<Tag> = [];
 var invalidSearchInput = String(data.getRandomNumber());
 
-describe("Application inventory filter validations", function () {
+describe("Application inventory filter validations", { tags: "@tier2" }, function () {
     before("Login and Create Test Data", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
+        // Perform login
         login();
 
         for (let i = 0; i < 3; i++) {

--- a/cypress/integration/tests/applicationinventory/application/import.test.ts
+++ b/cypress/integration/tests/applicationinventory/application/import.test.ts
@@ -12,6 +12,7 @@ import {
     selectItemsPerPage,
     deleteApplicationTableRows,
     preservecookies,
+    hasToBeSkipped,
 } from "../../../../utils/utils";
 import { ApplicationInventory } from "../../../models/applicationinventory/applicationinventory";
 import { BusinessServices } from "../../../models/businessservices";
@@ -23,8 +24,11 @@ const businessService = new BusinessServices("Finance and HR");
 const filePath = "app_import/";
 var applicationsList: Array<ApplicationInventory> = [];
 
-describe("Application import operations", () => {
+describe("Application import operations", { tags: "@tier1" }, () => {
     before("Login and create test data", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier1")) return;
+
         // Perform login
         login();
 
@@ -59,6 +63,9 @@ describe("Application import operations", () => {
     });
 
     after("Perform test data clean up", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier1")) return;
+
         // Delete the business service
         businessService.delete();
 
@@ -203,7 +210,6 @@ describe("Application import operations", () => {
         cy.wait("@getApplication");
 
         // Import csv having description and comments over the allowed limits
-        // Fails due to bug - https://issues.redhat.com/browse/TACKLE-268
         const fileName = "desc_comments_char_limit_rows.csv";
         importApplication(filePath + fileName);
         cy.wait(2000);

--- a/cypress/integration/tests/applicationinventory/application/interlinked.test.ts
+++ b/cypress/integration/tests/applicationinventory/application/interlinked.test.ts
@@ -1,6 +1,12 @@
 /// <reference types="cypress" />
 
-import { login, clickByText, notExists, preservecookies } from "../../../../utils/utils";
+import {
+    login,
+    clickByText,
+    notExists,
+    preservecookies,
+    hasToBeSkipped,
+} from "../../../../utils/utils";
 import { Tag } from "../../../models/tags";
 import { ApplicationInventory } from "../../../models/applicationinventory/applicationinventory";
 import { businessColumnSelector } from "../../../views/applicationinventory.view";
@@ -18,116 +24,126 @@ var businessservicesList: Array<BusinessServices> = [];
 var tagList: Array<Tag> = [];
 var applicationList: Array<ApplicationInventory> = [];
 
-describe("Application inventory interlinked to tags and business service", () => {
-    before("Login and Create Test Data", function () {
-        // Perform login
-        login();
+describe(
+    "Application inventory interlinked to tags and business service",
+    { tags: "@tier1" },
+    () => {
+        before("Login and Create Test Data", function () {
+            // Prevent hook from running, if the tag is excluded from run
+            if (hasToBeSkipped("@tier1")) return;
 
-        // Create multiple bussiness services and tags
-        for (let i = 0; i < 2; i++) {
-            const stakeholder = new Stakeholders(data.getEmail(), data.getFullName());
-            stakeholder.create();
-            stakeholdersList.push(stakeholder);
+            // Perform login
+            login();
 
-            // Create new business service
-            const businessservice = new BusinessServices(
-                data.getCompanyName(),
-                data.getDescription(),
-                stakeholder.name
-            );
-            businessservice.create();
-            businessservicesList.push(businessservice);
+            // Create multiple bussiness services and tags
+            for (let i = 0; i < 2; i++) {
+                const stakeholder = new Stakeholders(data.getEmail(), data.getFullName());
+                stakeholder.create();
+                stakeholdersList.push(stakeholder);
 
-            // Create new tag
-            const tag = new Tag(data.getRandomWord(6), data.getExistingTagtype());
-            tag.create();
-            tagList.push(tag);
+                // Create new business service
+                const businessservice = new BusinessServices(
+                    data.getCompanyName(),
+                    data.getDescription(),
+                    stakeholder.name
+                );
+                businessservice.create();
+                businessservicesList.push(businessservice);
 
-            // Navigate to application inventory tab and create new application
-            const application = new ApplicationInventory(
-                data.getAppName(),
-                data.getDescription(),
-                data.getDescription(),
-                businessservice.name,
-                [tag.name]
-            );
-            application.create();
-            applicationList.push(application);
-            cy.wait(2000);
-        }
-    });
+                // Create new tag
+                const tag = new Tag(data.getRandomWord(6), data.getExistingTagtype());
+                tag.create();
+                tagList.push(tag);
 
-    beforeEach("Persist session", function () {
-        // Save the session and token cookie for maintaining one login session
-        preservecookies();
-
-        // Interceptors
-        cy.intercept("POST", "/api/controls/business-service*").as("postBusinessService");
-        cy.intercept("GET", "/api/controls/business-service*").as("getBusinessService");
-
-        // Interceptors
-        cy.intercept("POST", "/api/controls/tag*").as("postTag");
-        cy.intercept("GET", "/api/controls/tag*").as("getTag");
-
-        // Interceptors
-        cy.intercept("GET", "/api/application-inventory/application*").as("getApplication");
-    });
-
-    after("Perform test data clean up", function () {
-        // Delete the applications and stakeholders created before the tests
-        stakeholdersList.forEach(function (stakeholder) {
-            stakeholder.delete();
+                // Navigate to application inventory tab and create new application
+                const application = new ApplicationInventory(
+                    data.getAppName(),
+                    data.getDescription(),
+                    data.getDescription(),
+                    businessservice.name,
+                    [tag.name]
+                );
+                application.create();
+                applicationList.push(application);
+                cy.wait(2000);
+            }
         });
 
-        // Delete application
-        applicationList.forEach(function (application) {
-            application.delete();
+        beforeEach("Persist session", function () {
+            // Save the session and token cookie for maintaining one login session
+            preservecookies();
+
+            // Interceptors
+            cy.intercept("POST", "/api/controls/business-service*").as("postBusinessService");
+            cy.intercept("GET", "/api/controls/business-service*").as("getBusinessService");
+
+            // Interceptors
+            cy.intercept("POST", "/api/controls/tag*").as("postTag");
+            cy.intercept("GET", "/api/controls/tag*").as("getTag");
+
+            // Interceptors
+            cy.intercept("GET", "/api/application-inventory/application*").as("getApplication");
         });
-        // Clean up business service and tags
-        businessservicesList[1].delete();
-        tagList[1].delete();
-    });
 
-    it("Business Service update and delete dependency on application inventory", function () {
-        // Navigate to Business Service and delete
-        clickByText(navMenu, controls);
-        clickByText(navTab, businessservices);
+        after("Perform test data clean up", function () {
+            // Prevent hook from running, if the tag is excluded from run
+            if (hasToBeSkipped("@tier1")) return;
 
-        //Delete associated business service
-        businessservicesList[0].delete();
-        notExists(businessservicesList[0].name);
+            // Delete the applications and stakeholders created before the tests
+            stakeholdersList.forEach(function (stakeholder) {
+                stakeholder.delete();
+            });
 
-        // Navigate to tags and delete
-        clickByText(navTab, tags);
-        tagList[0].delete();
-
-        // Navigate to application inventory
-        clickByText(navMenu, applicationinventory);
-        cy.wait(100);
-        cy.wait("@getApplication");
-
-        // Assert that deleted business service is removed from application
-        applicationList[0].getColumnText(businessColumnSelector, "");
-        cy.wait(100);
-
-        // Assert that deleted tag is removed
-        applicationList[0].expandApplicationRow();
-        applicationList[0].existsWithinRow(applicationList[0].name, "Tags", "");
-        applicationList[0].closeApplicationRow();
-
-        applicationList[0].edit({
-            business: businessservicesList[1].name,
-            tags: [tagList[1].name],
+            // Delete application
+            applicationList.forEach(function (application) {
+                application.delete();
+            });
+            // Clean up business service and tags
+            businessservicesList[1].delete();
+            tagList[1].delete();
         });
-        cy.wait("@getApplication");
 
-        // Assert that business service is updated
-        applicationList[0].getColumnText(businessColumnSelector, businessservicesList[1].name);
-        cy.wait(100);
+        it("Business Service update and delete dependency on application inventory", function () {
+            // Navigate to Business Service and delete
+            clickByText(navMenu, controls);
+            clickByText(navTab, businessservices);
 
-        // Assert that created tag exists
-        applicationList[0].expandApplicationRow();
-        applicationList[0].existsWithinRow(applicationList[0].name, "Tags", tagList[1].name);
-        applicationList[0].closeApplicationRow();
-    });
-});
+            //Delete associated business service
+            businessservicesList[0].delete();
+            notExists(businessservicesList[0].name);
+
+            // Navigate to tags and delete
+            clickByText(navTab, tags);
+            tagList[0].delete();
+
+            // Navigate to application inventory
+            clickByText(navMenu, applicationinventory);
+            cy.wait(100);
+            cy.wait("@getApplication");
+
+            // Assert that deleted business service is removed from application
+            applicationList[0].getColumnText(businessColumnSelector, "");
+            cy.wait(100);
+
+            // Assert that deleted tag is removed
+            applicationList[0].expandApplicationRow();
+            applicationList[0].existsWithinRow(applicationList[0].name, "Tags", "");
+            applicationList[0].closeApplicationRow();
+
+            applicationList[0].edit({
+                business: businessservicesList[1].name,
+                tags: [tagList[1].name],
+            });
+            cy.wait("@getApplication");
+
+            // Assert that business service is updated
+            applicationList[0].getColumnText(businessColumnSelector, businessservicesList[1].name);
+            cy.wait(100);
+
+            // Assert that created tag exists
+            applicationList[0].expandApplicationRow();
+            applicationList[0].existsWithinRow(applicationList[0].name, "Tags", tagList[1].name);
+            applicationList[0].closeApplicationRow();
+        });
+    }
+);

--- a/cypress/integration/tests/applicationinventory/application/pagination.test.ts
+++ b/cypress/integration/tests/applicationinventory/application/pagination.test.ts
@@ -6,10 +6,10 @@ import {
     selectItemsPerPage,
     preservecookies,
     deleteApplicationTableRows,
+    hasToBeSkipped,
 } from "../../../../utils/utils";
 import { navMenu } from "../../../views/menu.view";
-import { applicationinventory, button, tdTag, trTag, deleteAction } from "../../../types/constants";
-import { actionButton } from "../../../views/applicationinventory.view";
+import { applicationinventory } from "../../../types/constants";
 import { ApplicationInventory } from "../../../models/applicationinventory/applicationinventory";
 
 import * as data from "../../../../utils/data_utils";
@@ -17,8 +17,11 @@ import * as commonView from "../../../views/common.view";
 
 var applicationsList: Array<ApplicationInventory> = [];
 
-describe("Application inventory pagination validations", function () {
+describe("Application inventory pagination validations", { tags: "@tier3" }, function () {
     before("Login and Create Test Data", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier3")) return;
+
         // Perform login
         login();
 
@@ -177,7 +180,6 @@ describe("Application inventory pagination validations", function () {
     });
 
     it("Last page item(s) deletion, impact on page reload validation", function () {
-        // Issue - https://issues.redhat.com/browse/TACKLE-181
         // Navigate to Application inventory tab
         clickByText(navMenu, applicationinventory);
         cy.wait("@getApplications");

--- a/cypress/integration/tests/applicationinventory/application/sort.test.ts
+++ b/cypress/integration/tests/applicationinventory/application/sort.test.ts
@@ -9,6 +9,7 @@ import {
     verifySortDesc,
     getTableColumnData,
     preservecookies,
+    hasToBeSkipped,
 } from "../../../../utils/utils";
 import { navMenu } from "../../../views/menu.view";
 import { applicationinventory, name, tagCount, review } from "../../../types/constants";
@@ -18,8 +19,11 @@ import { ApplicationInventory } from "../../../models/applicationinventory/appli
 
 var applicationsList: Array<ApplicationInventory> = [];
 
-describe("Application inventory sort validations", function () {
+describe("Application inventory sort validations", { tags: "@tier2" }, function () {
     before("Login and Create Test Data", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Perform login
         login();
         var tagsList = ["C++", "COBOL", "Java"];

--- a/cypress/integration/tests/applicationinventory/manageimports/filter.test.ts
+++ b/cypress/integration/tests/applicationinventory/manageimports/filter.test.ts
@@ -10,6 +10,7 @@ import {
     selectItemsPerPage,
     deleteApplicationTableRows,
     preservecookies,
+    hasToBeSkipped,
 } from "../../../../utils/utils";
 import { navMenu } from "../../../views/menu.view";
 import { applicationinventory, button, clearAllFilters } from "../../../types/constants";
@@ -30,8 +31,11 @@ const filesToImport = [
 ];
 var invalidSearchInput = String(data.getRandomNumber());
 
-describe("Manage applications import filter validations", function () {
+describe("Manage applications import filter validations", { tags: "@tier2" }, function () {
     before("Login and create test data", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Perform login
         login();
 
@@ -83,6 +87,9 @@ describe("Manage applications import filter validations", function () {
     });
 
     after("Perform test data clean up", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Delete the business service
         businessService.delete();
 

--- a/cypress/integration/tests/applicationinventory/manageimports/pagination.test.ts
+++ b/cypress/integration/tests/applicationinventory/manageimports/pagination.test.ts
@@ -9,6 +9,7 @@ import {
     openManageImportsPage,
     deleteApplicationTableRows,
     preservecookies,
+    hasToBeSkipped,
 } from "../../../../utils/utils";
 import { navMenu } from "../../../views/menu.view";
 import { applicationinventory, button, tdTag, trTag, deleteAction } from "../../../types/constants";
@@ -27,8 +28,11 @@ const filesToImport = [
     "non_existing_tags_business_service_rows.csv",
 ];
 
-describe("Manage imports pagination validations", function () {
+describe("Manage imports pagination validations", { tags: "@tier3" }, function () {
     before("Login and Create Test Data", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier3")) return;
+
         // Perform login
         login();
 
@@ -110,6 +114,9 @@ describe("Manage imports pagination validations", function () {
     });
 
     after("Perform test data clean up", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier3")) return;
+
         // Delete the business service
         businessService.delete();
 

--- a/cypress/integration/tests/applicationinventory/manageimports/sort.test.ts
+++ b/cypress/integration/tests/applicationinventory/manageimports/sort.test.ts
@@ -13,6 +13,7 @@ import {
     selectItemsPerPage,
     deleteApplicationTableRows,
     preservecookies,
+    hasToBeSkipped,
 } from "../../../../utils/utils";
 import { navMenu } from "../../../views/menu.view";
 import { applicationinventory } from "../../../types/constants";
@@ -26,8 +27,11 @@ const businessService = new BusinessServices("Finance and HR");
 const filePath = "app_import/";
 var applicationsList: Array<ApplicationInventory> = [];
 
-describe("Manage applications import sort validations", function () {
+describe("Manage applications import sort validations", { tags: "@tier2" }, function () {
     before("Login and create test data", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Perform login
         login();
 
@@ -87,6 +91,9 @@ describe("Manage applications import sort validations", function () {
     });
 
     after("Perform test data clean up", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Delete the business service
         businessService.delete();
 

--- a/cypress/integration/tests/controls/businessservices/create.test.ts
+++ b/cypress/integration/tests/controls/businessservices/create.test.ts
@@ -7,6 +7,8 @@ import {
     submitForm,
     exists,
     notExists,
+    hasToBeSkipped,
+    preservecookies,
 } from "../../../../utils/utils";
 import { navMenu, navTab } from "../../../views/menu.view";
 import {
@@ -28,10 +30,18 @@ import * as commonView from "../../../../integration/views/common.view";
 import { BusinessServices } from "../../../models/businessservices";
 import * as data from "../../../../utils/data_utils";
 
-describe("Business service validations", () => {
-    beforeEach("Login", function () {
+describe("Business service validations", { tags: "@tier2" }, () => {
+    before("Login", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Perform login
         login();
+    });
+
+    beforeEach("Persist session", function () {
+        // Save the session and token cookie for maintaining one login session
+        preservecookies();
     });
 
     it("Business service field validations", function () {

--- a/cypress/integration/tests/controls/businessservices/crud.test.ts
+++ b/cypress/integration/tests/controls/businessservices/crud.test.ts
@@ -1,15 +1,23 @@
 /// <reference types="cypress" />
 
-import { exists, login, notExists } from "../../../../utils/utils";
+import { exists, hasToBeSkipped, login, notExists, preservecookies } from "../../../../utils/utils";
 import { BusinessServices } from "../../../models/businessservices";
 import { Stakeholders } from "../../../models/stakeholders";
 
 import * as data from "../../../../utils/data_utils";
 
-describe("Business service CRUD operations", () => {
-    beforeEach("Login", function () {
+describe("Business service CRUD operations", { tags: "@tier1" }, () => {
+    before("Login", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier1")) return;
+
         // Perform login
         login();
+    });
+
+    beforeEach("Persist session", function () {
+        // Save the session and token cookie for maintaining one login session
+        preservecookies();
 
         // Interceptors for business services
         cy.intercept("POST", "/api/controls/business-service*").as("postBusinessService");

--- a/cypress/integration/tests/controls/businessservices/filter.test.ts
+++ b/cypress/integration/tests/controls/businessservices/filter.test.ts
@@ -7,6 +7,7 @@ import {
     notExists,
     applySearchFilter,
     preservecookies,
+    hasToBeSkipped,
 } from "../../../../utils/utils";
 import { navMenu, navTab } from "../../../views/menu.view";
 import {
@@ -27,9 +28,14 @@ var businessservicesList: Array<BusinessServices> = [];
 var stakeholdersList: Array<Stakeholders> = [];
 var invalidSearchInput = String(data.getRandomNumber());
 
-describe("Business services filter validations", function () {
+describe("Business services filter validations", { tags: "@tier2" }, function () {
     before("Login and Create Test Data", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
+        // Peform login
         login();
+
         // Create multiple stakeholder owners
         for (let i = 0; i < 3; i++) {
             const stakeholder = new Stakeholders(data.getEmail(), data.getFullName());

--- a/cypress/integration/tests/controls/businessservices/interlinked.test.ts
+++ b/cypress/integration/tests/controls/businessservices/interlinked.test.ts
@@ -1,16 +1,25 @@
 /// <reference types="cypress" />
 
-import { login, selectItemsPerPage, clickByText, exists, notExists } from "../../../../utils/utils";
+import {
+    login,
+    selectItemsPerPage,
+    clickByText,
+    exists,
+    notExists,
+    hasToBeSkipped,
+} from "../../../../utils/utils";
 import { navTab } from "../../../views/menu.view";
 import { BusinessServices } from "../../../models/businessservices";
 import { Stakeholders } from "../../../models/stakeholders";
 import { tdTag, businessservices } from "../../../types/constants";
 import * as data from "../../../../utils/data_utils";
 
-describe("Business service linked to stakeholder", () => {
+describe("Business service linked to stakeholder", { tags: "@tier1" }, () => {
     beforeEach("Login", function () {
-        // Perform login
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier1")) return;
 
+        // Perform login
         login();
 
         // Interceptors for business services

--- a/cypress/integration/tests/controls/businessservices/pagination.test.ts
+++ b/cypress/integration/tests/controls/businessservices/pagination.test.ts
@@ -6,6 +6,7 @@ import {
     selectItemsPerPage,
     deleteTableRows,
     preservecookies,
+    hasToBeSkipped,
 } from "../../../../utils/utils";
 import { navMenu, navTab } from "../../../views/menu.view";
 import { controls, businessservices } from "../../../types/constants";
@@ -24,8 +25,11 @@ import {
 
 var businessservicesList: Array<BusinessServices> = [];
 
-describe("Business services pagination validations", function () {
+describe("Business services pagination validations", { tags: "@tier3" }, function () {
     before("Login and Create Test Data", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier3")) return;
+
         // Perform login
         login();
 
@@ -176,7 +180,6 @@ describe("Business services pagination validations", function () {
     });
 
     it("Last page item(s) deletion, impact on page reload validation", function () {
-        // Issue - https://issues.redhat.com/browse/TACKLE-155
         // Navigate to business services tab
         clickByText(navMenu, controls);
         clickByText(navTab, businessservices);

--- a/cypress/integration/tests/controls/businessservices/sort.test.ts
+++ b/cypress/integration/tests/controls/businessservices/sort.test.ts
@@ -9,6 +9,7 @@ import {
     verifySortDesc,
     getTableColumnData,
     preservecookies,
+    hasToBeSkipped,
 } from "../../../../utils/utils";
 import { navMenu, navTab } from "../../../views/menu.view";
 import { controls, businessservices, name, owner } from "../../../types/constants";
@@ -21,8 +22,11 @@ var stakeholdersList: Array<Stakeholders> = [];
 var businessservicesList: Array<BusinessServices> = [];
 var businessserviceNames: Array<string> = [];
 
-describe("Business services sort validations", function () {
+describe("Business services sort validations", { tags: "@tier2" }, function () {
     before("Login and Create Test Data", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Perform login
         login();
 

--- a/cypress/integration/tests/controls/jobfunctions/create.test.ts
+++ b/cypress/integration/tests/controls/jobfunctions/create.test.ts
@@ -6,6 +6,8 @@ import {
     submitForm,
     exists,
     notExists,
+    hasToBeSkipped,
+    preservecookies,
 } from "../../../../utils/utils";
 import {
     controls,
@@ -22,12 +24,20 @@ import { jobfunctionNameInput } from "../../../views/jobfunctions.view";
 import * as commonView from "../../../../integration/views/common.view";
 import * as data from "../../../../utils/data_utils";
 
-describe("Job Function Validations", () => {
+describe("Job Function Validations", { tags: "@tier2" }, () => {
     const jobfunction = new Jobfunctions(data.getJobTitle());
 
-    beforeEach("Login", function () {
+    before("Login", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Perform login
         login();
+    });
+
+    beforeEach("Persist session", function () {
+        // Save the session and token cookie for maintaining one login session
+        preservecookies();
 
         // Interceptors
         cy.intercept("POST", "/api/controls/job-function*").as("postJobfunctions");
@@ -92,7 +102,7 @@ describe("Job Function Validations", () => {
         cy.contains(button, createNewButton).should("exist");
     });
 
-    it("job function update and cancel validation", function () {
+    it("Job function update and cancel validation", function () {
         // Edit job function and cancel
         jobfunction.create();
         jobfunction.edit(data.getJobTitle(), true);

--- a/cypress/integration/tests/controls/jobfunctions/crud.test.ts
+++ b/cypress/integration/tests/controls/jobfunctions/crud.test.ts
@@ -1,13 +1,16 @@
 /// <reference types="cypress" />
 
-import { exists, login, notExists } from "../../../../utils/utils";
+import { exists, hasToBeSkipped, login, notExists } from "../../../../utils/utils";
 import { Jobfunctions } from "../../../models/jobfunctions";
 import * as data from "../../../../utils/data_utils";
 
-describe("Job Function CRUD operations", () => {
+describe("Job Function CRUD operations", { tags: "@tier1" }, () => {
     const jobfunction = new Jobfunctions(data.getJobTitle());
 
     before("Login", () => {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier1")) return;
+
         // Perform login
         login();
 

--- a/cypress/integration/tests/controls/jobfunctions/filter.test.ts
+++ b/cypress/integration/tests/controls/jobfunctions/filter.test.ts
@@ -1,6 +1,12 @@
 /// <reference types="cypress" />
 
-import { login, clickByText, exists, applySearchFilter } from "../../../../utils/utils";
+import {
+    login,
+    clickByText,
+    exists,
+    applySearchFilter,
+    hasToBeSkipped,
+} from "../../../../utils/utils";
 import { navMenu, navTab } from "../../../views/menu.view";
 import { controls, jobfunctions, button, name, clearAllFilters } from "../../../types/constants";
 
@@ -10,8 +16,11 @@ import * as data from "../../../../utils/data_utils";
 var jobfunctionsList: Array<Jobfunctions> = [];
 var invalidSearchInput = String(data.getRandomNumber());
 
-describe("Job function filter validations", function () {
+describe("Job function filter validations", { tags: "@tier2" }, function () {
     before("Login and Create Test Data", function () {
+        // Prevent before hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         login();
 
         // Create multiple job functions

--- a/cypress/integration/tests/controls/jobfunctions/pagination.test.ts
+++ b/cypress/integration/tests/controls/jobfunctions/pagination.test.ts
@@ -1,6 +1,12 @@
 /// <reference types="cypress" />
 
-import { login, clickByText, selectItemsPerPage, preservecookies } from "../../../../utils/utils";
+import {
+    login,
+    clickByText,
+    selectItemsPerPage,
+    preservecookies,
+    hasToBeSkipped,
+} from "../../../../utils/utils";
 import { navMenu, navTab } from "../../../views/menu.view";
 import { controls, jobfunctions } from "../../../types/constants";
 
@@ -18,8 +24,11 @@ import {
 
 var jobfunctionsList: Array<Jobfunctions> = [];
 
-describe("Job functions pagination validations", function () {
+describe("Job functions pagination validations", { tags: "@tier3" }, function () {
     before("Login and Create Test Data", function () {
+        // Prevent before hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier3")) return;
+
         // Perform login
         login();
 

--- a/cypress/integration/tests/controls/jobfunctions/sort.test.ts
+++ b/cypress/integration/tests/controls/jobfunctions/sort.test.ts
@@ -9,6 +9,7 @@ import {
     verifySortDesc,
     getTableColumnData,
     preservecookies,
+    hasToBeSkipped,
 } from "../../../../utils/utils";
 const { _ } = Cypress;
 import { navMenu, navTab } from "../../../views/menu.view";
@@ -19,8 +20,11 @@ import * as data from "../../../../utils/data_utils";
 
 var jobfunctionsList: Array<Jobfunctions> = [];
 
-describe("Job function sorting", function () {
+describe("Job function sorting", { tags: "@tier2" }, function () {
     before("Login and Create Test Data", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Perform login
         login();
 

--- a/cypress/integration/tests/controls/stakeholdergroups/create.test.ts
+++ b/cypress/integration/tests/controls/stakeholdergroups/create.test.ts
@@ -7,6 +7,8 @@ import {
     submitForm,
     exists,
     notExists,
+    hasToBeSkipped,
+    preservecookies,
 } from "../../../../utils/utils";
 import { navMenu, navTab } from "../../../views/menu.view";
 import {
@@ -27,12 +29,20 @@ import { Stakeholdergroups } from "../../../models/stakeholdergroups";
 import * as data from "../../../../utils/data_utils";
 import * as commonView from "../../../../integration/views/common.view";
 
-describe("Stakeholder groups validations", () => {
+describe("Stakeholder groups validations", { tags: "@tier2" }, () => {
     const stakeholdergroup = new Stakeholdergroups(data.getCompanyName(), data.getDescription());
 
-    beforeEach("Login", function () {
+    before("Login", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Perform login
         login();
+    });
+
+    beforeEach("Persist session", function () {
+        // Save the session and token cookie for maintaining one login session
+        preservecookies();
     });
 
     it("Stakeholder group field validations", function () {

--- a/cypress/integration/tests/controls/stakeholdergroups/crud.test.ts
+++ b/cypress/integration/tests/controls/stakeholdergroups/crud.test.ts
@@ -1,18 +1,34 @@
 /// <reference types="cypress" />
 
-import { login, selectItemsPerPage, click, exists, notExists } from "../../../../utils/utils";
+import {
+    login,
+    selectItemsPerPage,
+    click,
+    exists,
+    notExists,
+    hasToBeSkipped,
+    preservecookies,
+} from "../../../../utils/utils";
 import { Stakeholdergroups } from "../../../models/stakeholdergroups";
 import { Stakeholders } from "../../../models/stakeholders";
 import { tdTag, trTag } from "../../../types/constants";
 import * as data from "../../../../utils/data_utils";
 import { expandRow } from "../../../views/common.view";
 
-describe("Stakeholder group CRUD operations", () => {
+describe("Stakeholder group CRUD operations", { tags: "@tier1" }, () => {
     const stakeholder = new Stakeholders(data.getEmail(), data.getFullName());
 
-    beforeEach("Login", function () {
+    before("Login", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier1")) return;
+
         // Perform login
         login();
+    });
+
+    beforeEach("Persist session", function () {
+        // Save the session and token cookie for maintaining one login session
+        preservecookies();
 
         // Interceptors
         cy.intercept("POST", "/api/controls/stakeholder-group*").as("postStakeholdergroups");

--- a/cypress/integration/tests/controls/stakeholdergroups/filter.test.ts
+++ b/cypress/integration/tests/controls/stakeholdergroups/filter.test.ts
@@ -4,11 +4,11 @@ import {
     login,
     clickByText,
     exists,
-    notExists,
     click,
     applySearchFilter,
     selectItemsPerPage,
     preservecookies,
+    hasToBeSkipped,
 } from "../../../../utils/utils";
 import { navMenu, navTab } from "../../../views/menu.view";
 import {
@@ -33,8 +33,11 @@ var stakeholdersList: Array<Stakeholders> = [];
 var stakeholdergroupsList: Array<Stakeholdergroups> = [];
 var invalidSearchInput = data.getRandomNumber();
 
-describe("Stakeholder groups filter validations", function () {
+describe("Stakeholder groups filter validations", { tags: "@tier2" }, function () {
     before("Login and Create Test Data", function () {
+        // Prevent before hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Perform login
         login();
 

--- a/cypress/integration/tests/controls/stakeholdergroups/interlinked.test.ts
+++ b/cypress/integration/tests/controls/stakeholdergroups/interlinked.test.ts
@@ -8,6 +8,7 @@ import {
     exists,
     notExists,
     preservecookies,
+    hasToBeSkipped,
 } from "../../../../utils/utils";
 import { navTab } from "../../../views/menu.view";
 import { Stakeholdergroups } from "../../../models/stakeholdergroups";
@@ -19,8 +20,11 @@ import * as data from "../../../../utils/data_utils";
 var stakeholdersList: Array<Stakeholders> = [];
 var membersList: Array<string> = [];
 
-describe("Stakeholder group linked to stakeholder members", () => {
+describe("Stakeholder group linked to stakeholder members", { tags: "@tier1" }, () => {
     before("Login and Create Test Data", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier1")) return;
+
         // Perform login
         login();
 

--- a/cypress/integration/tests/controls/stakeholdergroups/pagination.test.ts
+++ b/cypress/integration/tests/controls/stakeholdergroups/pagination.test.ts
@@ -6,6 +6,7 @@ import {
     selectItemsPerPage,
     deleteTableRows,
     preservecookies,
+    hasToBeSkipped,
 } from "../../../../utils/utils";
 import { navMenu, navTab } from "../../../views/menu.view";
 import { controls, stakeholdergroups } from "../../../types/constants";
@@ -24,8 +25,11 @@ import {
 
 var stakeholdergroupsList: Array<Stakeholdergroups> = [];
 
-describe("Stakeholder groups pagination validations", function () {
+describe("Stakeholder groups pagination validations", { tags: "@tier3" }, function () {
     before("Login and Create Test Data", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier3")) return;
+
         // Perform login
         login();
 

--- a/cypress/integration/tests/controls/stakeholdergroups/sort.test.ts
+++ b/cypress/integration/tests/controls/stakeholdergroups/sort.test.ts
@@ -9,6 +9,7 @@ import {
     verifySortDesc,
     getTableColumnData,
     preservecookies,
+    hasToBeSkipped,
 } from "../../../../utils/utils";
 import * as data from "../../../../utils/data_utils";
 import { navMenu, navTab } from "../../../views/menu.view";
@@ -20,8 +21,11 @@ var stakeholdergroupsList: Array<Stakeholdergroups> = [];
 var stakeholdersList: Array<Stakeholders> = [];
 var stakeholderNames: Array<string> = [];
 
-describe("Stakeholder groups sort validations", function () {
+describe("Stakeholder groups sort validations", { tags: "@tier2" }, function () {
     before("Login and Create Test Data", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Perform login
         login();
 

--- a/cypress/integration/tests/controls/tags/tag/create.test.ts
+++ b/cypress/integration/tests/controls/tags/tag/create.test.ts
@@ -7,6 +7,7 @@ import {
     submitForm,
     click,
     preservecookies,
+    hasToBeSkipped,
 } from "../../../../../utils/utils";
 import { navMenu, navTab } from "../../../../views/menu.view";
 import {
@@ -29,8 +30,11 @@ import { Tag } from "../../../../models/tags";
 import * as commonView from "../../../../../integration/views/common.view";
 import * as data from "../../../../../utils/data_utils";
 
-describe("Tag validations", () => {
+describe("Tag validations", { tags: "@tier2" }, () => {
     before("Login", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Perform login
         login();
     });

--- a/cypress/integration/tests/controls/tags/tag/crud.test.ts
+++ b/cypress/integration/tests/controls/tags/tag/crud.test.ts
@@ -7,14 +7,18 @@ import {
     existsWithinRow,
     closeRowDetails,
     notExistsWithinRow,
+    hasToBeSkipped,
 } from "../../../../../utils/utils";
 import { Tag } from "../../../../models/tags";
 
 import { tdTag } from "../../../../types/constants";
 import * as data from "../../../../../utils/data_utils";
 
-describe("Tag CRUD operations", () => {
+describe("Tag CRUD operations", { tags: "@tier1" }, () => {
     beforeEach("Login", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier1")) return;
+
         // Perform login
         login();
 

--- a/cypress/integration/tests/controls/tags/tag/filter.test.ts
+++ b/cypress/integration/tests/controls/tags/tag/filter.test.ts
@@ -7,6 +7,7 @@ import {
     expandRowDetails,
     existsWithinRow,
     closeRowDetails,
+    hasToBeSkipped,
 } from "../../../../../utils/utils";
 import { navMenu, navTab } from "../../../../views/menu.view";
 import {
@@ -21,8 +22,11 @@ import { Tag } from "../../../../models/tags";
 
 import * as data from "../../../../../utils/data_utils";
 
-describe("Tags filter validations", function () {
+describe("Tags filter validations", { tags: "@tier2" }, function () {
     before("Login", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Perform login
         login();
 

--- a/cypress/integration/tests/controls/tags/tagtype/create.test.ts
+++ b/cypress/integration/tests/controls/tags/tagtype/create.test.ts
@@ -7,6 +7,7 @@ import {
     submitForm,
     click,
     preservecookies,
+    hasToBeSkipped,
 } from "../../../../../utils/utils";
 import { navMenu, navTab } from "../../../../views/menu.view";
 import {
@@ -33,8 +34,11 @@ import { Tagtype } from "../../../../models/tags";
 import * as commonView from "../../../../../integration/views/common.view";
 import * as data from "../../../../../utils/data_utils";
 
-describe("Tag type validations", () => {
+describe("Tag type validations", { tags: "@tier2" }, () => {
     before("Login", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Perform login
         login();
     });

--- a/cypress/integration/tests/controls/tags/tagtype/crud.test.ts
+++ b/cypress/integration/tests/controls/tags/tagtype/crud.test.ts
@@ -1,15 +1,29 @@
 /// <reference types="cypress" />
 
-import { login, exists, notExists } from "../../../../../utils/utils";
+import {
+    login,
+    exists,
+    notExists,
+    hasToBeSkipped,
+    preservecookies,
+} from "../../../../../utils/utils";
 import { Tagtype, Tag } from "../../../../models/tags";
 
 import * as data from "../../../../../utils/data_utils";
 import { color, rank, tagCount } from "../../../../types/constants";
 
-describe("Tag Type CRUD operations", () => {
-    beforeEach("Login", function () {
+describe("Tag Type CRUD operations", { tags: "@tier1" }, () => {
+    before("Login", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier1")) return;
+
         // Perform login
         login();
+    });
+
+    beforeEach("Persist session", function () {
+        // Save the session and token cookie for maintaining one login session
+        preservecookies();
 
         // Interceptors
         cy.intercept("POST", "/api/controls/tag-type*").as("postTagtype");

--- a/cypress/integration/tests/controls/tags/tagtype/filter.test.ts
+++ b/cypress/integration/tests/controls/tags/tagtype/filter.test.ts
@@ -1,13 +1,22 @@
 /// <reference types="cypress" />
 
-import { login, clickByText, exists, applySearchFilter } from "../../../../../utils/utils";
+import {
+    login,
+    clickByText,
+    exists,
+    applySearchFilter,
+    hasToBeSkipped,
+} from "../../../../../utils/utils";
 import { navMenu, navTab } from "../../../../views/menu.view";
 import { controls, button, clearAllFilters, tags, tagtype } from "../../../../types/constants";
 
 import * as data from "../../../../../utils/data_utils";
 
-describe("Tag type filter validations", function () {
+describe("Tag type filter validations", { tags: "@tier2" }, function () {
     before("Login", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Perform login
         login();
 

--- a/cypress/integration/tests/controls/tags/tagtype/pagination.test.ts
+++ b/cypress/integration/tests/controls/tags/tagtype/pagination.test.ts
@@ -5,6 +5,7 @@ import {
     clickByText,
     selectItemsPerPage,
     preservecookies,
+    hasToBeSkipped,
 } from "../../../../../utils/utils";
 import { navMenu, navTab } from "../../../../views/menu.view";
 import { controls, tags } from "../../../../types/constants";
@@ -23,8 +24,11 @@ import {
 
 var tagtypeList: Array<Tagtype> = [];
 
-describe("Tag type pagination validations", function () {
+describe("Tag type pagination validations", { tags: "@tier3" }, function () {
     before("Login and Create Test Data", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier3")) return;
+
         // Perform login
         login();
 

--- a/cypress/integration/tests/controls/tags/tagtype/sort.test.ts
+++ b/cypress/integration/tests/controls/tags/tagtype/sort.test.ts
@@ -9,12 +9,16 @@ import {
     verifySortDesc,
     getTableColumnData,
     preservecookies,
+    hasToBeSkipped,
 } from "../../../../../utils/utils";
 import { navMenu, navTab } from "../../../../views/menu.view";
 import { controls, tags, tagtype, rank, tagCount } from "../../../../types/constants";
 
-describe("Tag type sort validations", function () {
+describe("Tag type sort validations", { tags: "@tier2" }, function () {
     before("Login", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Perform login
         login();
     });
@@ -37,7 +41,6 @@ describe("Tag type sort validations", function () {
         const unsortedList = getTableColumnData(tagtype);
 
         // Sort the tag type by name in ascending order
-        // Issue for sorting corner cases - https://issues.redhat.com/browse/TACKLE-231
         sortAsc(tagtype);
         cy.wait(2000);
 

--- a/cypress/integration/tests/reports/filter.test.ts
+++ b/cypress/integration/tests/reports/filter.test.ts
@@ -7,6 +7,7 @@ import {
     getTableColumnData,
     selectFilter,
     preservecookies,
+    hasToBeSkipped,
 } from "../../../utils/utils";
 import { navMenu } from "../../views/menu.view";
 import {
@@ -41,8 +42,11 @@ var stakeholdersList: Array<Stakeholders> = [];
 var tagList: Array<Tag> = [];
 var invalidSearchInput = String(data.getRandomNumber());
 
-describe("Reports filter validations", () => {
+describe("Reports filter validations", { tags: "@tier2" }, () => {
     before("Login and create test data", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Perform login
         login();
 
@@ -94,6 +98,9 @@ describe("Reports filter validations", () => {
     });
 
     after("Perform test data clean up", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Delete the stakeholder
         stakeholdersList.forEach(function (stakeholder) {
             stakeholder.delete();

--- a/cypress/integration/tests/reports/pagination.test.ts
+++ b/cypress/integration/tests/reports/pagination.test.ts
@@ -1,6 +1,12 @@
 /// <reference types="cypress" />
 
-import { login, clickByText, selectItemsPerPage, preservecookies } from "../../../utils/utils";
+import {
+    login,
+    clickByText,
+    selectItemsPerPage,
+    preservecookies,
+    hasToBeSkipped,
+} from "../../../utils/utils";
 import { navMenu } from "../../views/menu.view";
 import { reports, applicationinventory } from "../../types/constants";
 import { ApplicationInventory } from "../../models/applicationinventory/applicationinventory";
@@ -16,8 +22,11 @@ import * as commonView from "../../views/common.view";
 var applicationsList: Array<ApplicationInventory> = [];
 var stakeholdersList: Array<Stakeholders> = [];
 
-describe("Reports pagination validations", () => {
+describe("Reports pagination validations", { tags: "@tier3" }, () => {
     before("Login and create test data", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier3")) return;
+
         // Perform login
         login();
 
@@ -84,6 +93,9 @@ describe("Reports pagination validations", () => {
     });
 
     after("Perform test data clean up", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier3")) return;
+
         // Delete the stakeholder
         stakeholdersList.forEach(function (stakeholder) {
             stakeholder.delete();

--- a/cypress/integration/tests/reports/sort.test.ts
+++ b/cypress/integration/tests/reports/sort.test.ts
@@ -9,6 +9,7 @@ import {
     getTableColumnData,
     sortAsc,
     preservecookies,
+    hasToBeSkipped,
 } from "../../../utils/utils";
 import { navMenu } from "../../views/menu.view";
 import {
@@ -27,8 +28,11 @@ import { Stakeholders } from "../../models/stakeholders";
 var applicationsList: Array<ApplicationInventory> = [];
 var stakeholdersList: Array<Stakeholders> = [];
 
-describe("Reports sort validations", () => {
+describe("Reports sort validations", { tags: "@tier2" }, () => {
     before("Login and create test data", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Perform login
         login();
 
@@ -60,6 +64,9 @@ describe("Reports sort validations", () => {
     });
 
     after("Perform test data clean up", function () {
+        // Prevent hook from running, if the tag is excluded from run
+        if (hasToBeSkipped("@tier2")) return;
+
         // Delete the stakeholder
         stakeholdersList.forEach(function (stakeholder) {
             stakeholder.delete();

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -176,7 +176,7 @@ export function applySearchFilter(
             }
         }
     }
-    cy.wait(2000);
+    cy.wait(4000);
 }
 
 export function sortAsc(sortCriteria: string): void {

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -414,3 +414,16 @@ export function hasToBeSkipped(tagName: string): boolean {
     }
     return false;
 }
+
+// Perform edit/delete action on the specified row selector
+export function performRowAction(
+    rowSelector: string,
+    buttonName: string,
+    hasParentTd = true
+): void {
+    if (hasParentTd) {
+        cy.get(tdTag).contains(rowSelector).parent(tdTag).siblings(tdTag).find(buttonName).click();
+    } else {
+        cy.get(tdTag).contains(rowSelector).siblings(tdTag).find(buttonName).click();
+    }
+}


### PR DESCRIPTION
This PR is in continuation to [PR](https://github.com/konveyor/tackle-ui-tests/pull/99)

- All the specs have been modified to include a tag based on tier
- Additionally, added some optimisations for edit and delete click actions for all the controls

Below is the screenshot of execution for **_tier 1 tests_**. The tier wise break up has reduced the minimum tests to run to 26 from 131, with an average execution time of around 28 minutes.

![tier1-all-specs-result](https://user-images.githubusercontent.com/43022982/135114030-86a265f7-68d5-4437-8b39-a631284d753d.png)
