### PR TITLE
Draft: Add baseUrl, use it in login function And refact navigate to stakehol…

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -3,13 +3,14 @@
     "viewportHeight": 880,
     "video": false,
     "env": {
-        "user": "",
-        "pass": "",
-        "tackleUrl": ""
+        "user": "admin",
+        "pass": "qum5net",
+        "tackleUrl": "https://tackle-konveyor-tackle.apps.mig01.cnv-qe.rhcloud.com/"
     },
     "retries": {
         "runMode": 2,
         "openMode": 0
     },
-    "defaultCommandTimeout": 8000
+    "defaultCommandTimeout": 8000,
+    "baseUrl": "https://tackle-konveyor-tackle.apps.mig01.cnv-qe.rhcloud.com/"
 }

--- a/cypress/integration/tests/controls/stakeholdergroups/create.test.ts
+++ b/cypress/integration/tests/controls/stakeholdergroups/create.test.ts
@@ -47,8 +47,9 @@ describe("Stakeholder groups validations", { tags: "@tier2" }, () => {
 
     it("Stakeholder group field validations", function () {
         // Navigate to stakeholder group tab and click "Create New" button
-        clickByText(navMenu, controls);
-        clickByText(navTab, stakeholdergroups);
+        // clickByText(navMenu, controls);
+        // clickByText(navTab, stakeholdergroups);
+        
         clickByText(button, createNewButton);
 
         // Name constraints

--- a/cypress/integration/tests/controls/stakeholders/create.test.ts
+++ b/cypress/integration/tests/controls/stakeholders/create.test.ts
@@ -55,8 +55,16 @@ describe("Stakeholder validations", { tags: "@tier2" }, () => {
 
     it("Stakeholder field validations", function () {
         // Navigate to stakeholder tab and click "Create New" button
-        clickByText(navMenu, controls);
-        clickByText(navTab, stakeholders);
+        // clickByText(navMenu, controls);
+        // clickByText(navTab, stakeholders);
+        
+        cy.visit({
+            url: '/controls/stakeholders',
+            method: 'GET',
+          })
+
+      
+        
         clickByText(button, createNewButton);
 
         // Email constraints

--- a/cypress/integration/views/menu.view.ts
+++ b/cypress/integration/views/menu.view.ts
@@ -1,2 +1,3 @@
-export const navMenu = "a.pf-c-nav__link";
+export const navMenu = "#nav-primary";
 export const navTab = "span.pf-c-tabs__item-text";
+document.querySelector("#nav-primary")

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -58,7 +58,7 @@ export function cancelForm(): void {
 }
 
 export function login(): void {
-    cy.visit(tackleUiUrl);
+    cy.visit("/");
     inputText(loginView.userNameInput, userName);
     inputText(loginView.userPasswordInput, userPassword);
     click(loginView.loginButton);


### PR DESCRIPTION
Add baseUrl env  so cy.visit() may use relative path
This enables easily navigate between pages without using the navigation menu.

Use visit("/") in login() 

Navigate to the stakeholder groups page using visit instead of clicking the button


- `Request review` from reviewers
    - sshveta
    - nitishSr
    - ganeshhubale
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
