### PR TITLE
RFR - Function selectWithinModal  added and tag creation fixed

### DIFF
--- a/cypress/integration/models/tags.ts
+++ b/cypress/integration/models/tags.ts
@@ -11,6 +11,7 @@ import {
     checkSuccessAlert,
     expandRowDetails,
     closeRowDetails,
+    selectWithinModal,
 } from "../../utils/utils";
 import * as commonView from "../views/common.view";
 import {
@@ -41,7 +42,7 @@ export class Tag {
     }
 
     protected selectTagtype(tagtype: string): void {
-        click(dropdownMenuToggle);
+        selectWithinModal(dropdownMenuToggle);
         clickByText(button, tagtype);
     }
 

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -759,3 +759,9 @@ export function selectUserPerspective(userType: string): void {
     click(optionMenu);
     clickByText(userPerspectiveMenu, userType);
 }
+
+export function selectWithinModal(selector: string): void {
+    cy.get("[id^=pf-modal-part-]").within(() => {
+        click(selector);
+    });
+}


### PR DESCRIPTION
Created function selectWithinModal to search for tag type dropdown within modal window only to avoid locating 2 DOM objects with the same captions

Fixed tag creation method, now it is using new function and doesn't fail

<!-- Add pull request description here -->

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nitishSr
    - ganeshhubale
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
