### PR TITLE
[RFR] Another fix for goToPage()

### DIFF
--- a/cypress/integration/models/developer/controls/businessservices.ts
+++ b/cypress/integration/models/developer/controls/businessservices.ts
@@ -73,9 +73,11 @@ export class BusinessServices {
     }
 
     // TODO: Refactor this method so that it will return list from particular page or full list, to take into account amount of items per page
-    public static getList(amountPerPage = 100, pageNumber = 1) {
+    public static getList(amountPerPage = 100, pageNumber?: number) {
         this.openList(amountPerPage);
-        goToPage(pageNumber);
+        if (pageNumber) {
+            goToPage(pageNumber);
+        }
         return new Promise<BusinessServices[]>((resolve) => {
             let list = [];
             cy.get(commonView.appTable, { timeout: 15 * SEC })


### PR DESCRIPTION
```
        if (pageNumber) {
            goToPage(pageNumber);
        }
```
Now this method will be called only if `pageNumber` will defined which normally will occur only if we expect to have more pages
<!-- Add pull request description here -->

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
