### PR TITLE
[RFR] Implement proxy port validation

### DIFF
--- a/cypress/integration/models/administrator/proxy/proxy.ts
+++ b/cypress/integration/models/administrator/proxy/proxy.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../../utils/utils";
 import { button } from "../../../types/constants";
 import { CredentialsProxyData, ProxyData } from "../../../types/types";
+import { submitButton } from "../../../../integration/views/common.view";
 
 export class Proxy {
     hostname;
@@ -56,6 +57,15 @@ export class Proxy {
         submitForm();
     }
 
+    protected configureInvalidProxy(type: string): void {
+        cy.wait(5000);
+        this.enableSwitch(`#${type}Proxy`);
+        inputText(`[name="${type}Host"]`, this.hostname);
+        inputText(`[name="${type}Port"]`, "Invalid port");
+        cy.get("#port-helper").contains("This field is required");
+        cy.get(submitButton).should("be.disabled");
+    }
+
     protected unConfigureProxy(type: string): void {
         clearInput(`[name="${type}Host"]`);
         clearInput(`[name="${type}Port"]`);
@@ -81,14 +91,26 @@ export class Proxy {
         }
     }
 
+    enableInvalidProxy(): void {
+        Proxy.open();
+        if (this.httpEnabled) {
+            this.configureInvalidProxy("http");
+        }
+        if (this.httpsEnabled) {
+            this.configureInvalidProxy("https");
+        }
+    }
+
     disable(): void {
         Proxy.open();
         clearInput('[aria-label="excluded"]');
         if (this.httpEnabled) {
             this.unConfigureProxy("http");
+            this.httpEnabled = false;
         }
         if (this.httpsEnabled) {
             this.unConfigureProxy("https");
+            this.httpsEnabled = false;
         }
     }
 

--- a/cypress/integration/models/administrator/proxy/proxy.ts
+++ b/cypress/integration/models/administrator/proxy/proxy.ts
@@ -41,6 +41,10 @@ export class Proxy {
         selectCheckBox(selector);
     }
 
+    disableSwitch(selector): void {
+        unSelectCheckBox(selector);
+    }
+
     protected configureProxy(type: string): void {
         cy.wait(5000); // This wait is required because of problems with page rendering, will be fixed later
         this.enableSwitch(`#${type}Proxy`);
@@ -60,7 +64,7 @@ export class Proxy {
     protected unConfigureProxy(type: string): void {
         clearInput(`[name="${type}Host"]`);
         clearInput(`[name="${type}Port"]`);
-        unSelectCheckBox(`#${type}Proxy`);
+        this.disableSwitch(`#${type}Proxy`);
     }
 
     fillExcludeList(): void {

--- a/cypress/integration/models/administrator/proxy/proxy.ts
+++ b/cypress/integration/models/administrator/proxy/proxy.ts
@@ -11,6 +11,7 @@ import {
 } from "../../../../utils/utils";
 import { button } from "../../../types/constants";
 import { CredentialsProxyData, ProxyData } from "../../../types/types";
+import { ProxyType, ProxyViewSelectors } from "../../../views/proxy.view";
 
 export class Proxy {
     hostname;
@@ -69,6 +70,20 @@ export class Proxy {
         });
         cy.log(fullList);
         inputText('[aria-label="excluded"]', fullList);
+    }
+
+    fillHost(type: ProxyType, host: string): void {
+        inputText(
+            type === ProxyType.http ? ProxyViewSelectors.httpHost : ProxyViewSelectors.httpsHost,
+            host
+        );
+    }
+
+    fillPort(type: ProxyType, port: string): void {
+        inputText(
+            type === ProxyType.http ? ProxyViewSelectors.httpPort : ProxyViewSelectors.httpsPort,
+            port
+        );
     }
 
     enable(): void {

--- a/cypress/integration/models/administrator/proxy/proxy.ts
+++ b/cypress/integration/models/administrator/proxy/proxy.ts
@@ -11,7 +11,6 @@ import {
 } from "../../../../utils/utils";
 import { button } from "../../../types/constants";
 import { CredentialsProxyData, ProxyData } from "../../../types/types";
-import { submitButton } from "../../../../integration/views/common.view";
 
 export class Proxy {
     hostname;
@@ -57,15 +56,6 @@ export class Proxy {
         submitForm();
     }
 
-    protected configureInvalidProxy(type: string): void {
-        cy.wait(5000);
-        this.enableSwitch(`#${type}Proxy`);
-        inputText(`[name="${type}Host"]`, this.hostname);
-        inputText(`[name="${type}Port"]`, "Invalid port");
-        cy.get("#port-helper").contains("This field is required");
-        cy.get(submitButton).should("be.disabled");
-    }
-
     protected unConfigureProxy(type: string): void {
         clearInput(`[name="${type}Host"]`);
         clearInput(`[name="${type}Port"]`);
@@ -88,16 +78,6 @@ export class Proxy {
         }
         if (this.httpsEnabled) {
             this.configureProxy("https");
-        }
-    }
-
-    enableInvalidProxy(): void {
-        Proxy.open();
-        if (this.httpEnabled) {
-            this.configureInvalidProxy("http");
-        }
-        if (this.httpsEnabled) {
-            this.configureInvalidProxy("https");
         }
     }
 

--- a/cypress/integration/tests/administrator/proxy/proxy.enable.disable.test.ts
+++ b/cypress/integration/tests/administrator/proxy/proxy.enable.disable.test.ts
@@ -9,7 +9,7 @@ import { Proxy } from "../../../models/administrator/proxy/proxy";
 import { CredentialsProxy } from "../../../models/administrator/credentials/credentialsProxy";
 import { getRandomCredentialsData, getRandomProxyData } from "../../../../utils/data_utils";
 import { CredentialType } from "../../../types/constants";
-import { fillHost, fillPort, ProxyType, ProxyViewSelectors } from "../../../views/proxy.view";
+import { ProxyType, ProxyViewSelectors } from "../../../views/proxy.view";
 import { submitButton } from "../../../../integration/views/common.view";
 
 describe("Proxy operations", () => {
@@ -33,8 +33,8 @@ describe("Proxy operations", () => {
     it("Http Proxy port and host field validation", function () {
         Proxy.open();
         selectCheckBox(ProxyViewSelectors.httpSwitch);
-        fillHost(ProxyType.http, proxy.hostname);
-        fillPort(ProxyType.http, "Invalid port");
+        proxy.fillHost(ProxyType.http, proxy.hostname);
+        proxy.fillPort(ProxyType.http, "Invalid port");
         cy.get(ProxyViewSelectors.portHelper).contains("This field is required");
         cy.get(submitButton).should("be.disabled");
         unSelectCheckBox(ProxyViewSelectors.httpSwitch);
@@ -43,8 +43,8 @@ describe("Proxy operations", () => {
     it("Https Proxy port and host field validation", function () {
         Proxy.open();
         selectCheckBox(ProxyViewSelectors.httpsSwitch);
-        fillHost(ProxyType.https, proxy.hostname);
-        fillPort(ProxyType.https, "Invalid port");
+        proxy.fillHost(ProxyType.https, proxy.hostname);
+        proxy.fillPort(ProxyType.https, "Invalid port");
         cy.get(ProxyViewSelectors.portHelper).contains("This field is required");
         cy.get(submitButton).should("be.disabled");
         unSelectCheckBox(ProxyViewSelectors.httpsSwitch);

--- a/cypress/integration/tests/administrator/proxy/proxy.enable.disable.test.ts
+++ b/cypress/integration/tests/administrator/proxy/proxy.enable.disable.test.ts
@@ -22,6 +22,27 @@ describe("Proxy operations", () => {
         preservecookies();
     });
 
+    it("Http Proxy validation", function () {
+        proxy.httpEnabled = true;
+        proxy.enableInvalidProxy();
+        proxy.disable();
+    });
+
+    it("Https Proxy validation", function () {
+        proxy.httpsEnabled = true;
+        proxy.enableInvalidProxy();
+        proxy.disable();
+    });
+
+    it("Enable HTTP proxy ", function () {
+        proxy.httpEnabled = true;
+        proxy.enable();
+    });
+
+    it("Disable HTTP proxy", function () {
+        proxy.disable();
+    });
+
     it("Enable HTTPS proxy", () => {
         proxy.httpsEnabled = true;
         proxy.excludeList = ["127.0.0.1", "github.com"];

--- a/cypress/integration/tests/administrator/proxy/proxy.enable.disable.test.ts
+++ b/cypress/integration/tests/administrator/proxy/proxy.enable.disable.test.ts
@@ -32,22 +32,22 @@ describe("Proxy operations", () => {
 
     it("Http Proxy port and host field validation", function () {
         Proxy.open();
-        selectCheckBox(ProxyViewSelectors.httpSwitch);
+        proxy.enableSwitch(ProxyViewSelectors.httpSwitch);
         proxy.fillHost(ProxyType.http, proxy.hostname);
         proxy.fillPort(ProxyType.http, "Invalid port");
         cy.get(ProxyViewSelectors.portHelper).contains("This field is required");
         cy.get(submitButton).should("be.disabled");
-        unSelectCheckBox(ProxyViewSelectors.httpSwitch);
+        proxy.disableSwitch(ProxyViewSelectors.httpSwitch);
     });
 
     it("Https Proxy port and host field validation", function () {
         Proxy.open();
-        selectCheckBox(ProxyViewSelectors.httpsSwitch);
+        proxy.enableSwitch(ProxyViewSelectors.httpsSwitch);
         proxy.fillHost(ProxyType.https, proxy.hostname);
         proxy.fillPort(ProxyType.https, "Invalid port");
         cy.get(ProxyViewSelectors.portHelper).contains("This field is required");
         cy.get(submitButton).should("be.disabled");
-        unSelectCheckBox(ProxyViewSelectors.httpsSwitch);
+        proxy.disableSwitch(ProxyViewSelectors.httpsSwitch);
     });
 
     it("Enable HTTP proxy ", function () {

--- a/cypress/integration/tests/administrator/proxy/proxy.enable.disable.test.ts
+++ b/cypress/integration/tests/administrator/proxy/proxy.enable.disable.test.ts
@@ -1,8 +1,16 @@
-import { hasToBeSkipped, login, preservecookies } from "../../../../utils/utils";
+import {
+    hasToBeSkipped,
+    login,
+    preservecookies,
+    selectCheckBox,
+    unSelectCheckBox,
+} from "../../../../utils/utils";
 import { Proxy } from "../../../models/administrator/proxy/proxy";
 import { CredentialsProxy } from "../../../models/administrator/credentials/credentialsProxy";
 import { getRandomCredentialsData, getRandomProxyData } from "../../../../utils/data_utils";
 import { CredentialType } from "../../../types/constants";
+import { fillHost, fillPort, ProxyType, ProxyViewSelectors } from "../../../views/proxy.view";
+import { submitButton } from "../../../../integration/views/common.view";
 
 describe("Proxy operations", () => {
     let proxy = new Proxy(getRandomProxyData());
@@ -22,16 +30,24 @@ describe("Proxy operations", () => {
         preservecookies();
     });
 
-    it("Http Proxy validation", function () {
-        proxy.httpEnabled = true;
-        proxy.enableInvalidProxy();
-        proxy.disable();
+    it("Http Proxy port and host field validation", function () {
+        Proxy.open();
+        selectCheckBox(ProxyViewSelectors.httpSwitch);
+        fillHost(ProxyType.http, proxy.hostname);
+        fillPort(ProxyType.http, "Invalid port");
+        cy.get(ProxyViewSelectors.portHelper).contains("This field is required");
+        cy.get(submitButton).should("be.disabled");
+        unSelectCheckBox(ProxyViewSelectors.httpSwitch);
     });
 
-    it("Https Proxy validation", function () {
-        proxy.httpsEnabled = true;
-        proxy.enableInvalidProxy();
-        proxy.disable();
+    it("Https Proxy port and host field validation", function () {
+        Proxy.open();
+        selectCheckBox(ProxyViewSelectors.httpsSwitch);
+        fillHost(ProxyType.https, proxy.hostname);
+        fillPort(ProxyType.https, "Invalid port");
+        cy.get(ProxyViewSelectors.portHelper).contains("This field is required");
+        cy.get(submitButton).should("be.disabled");
+        unSelectCheckBox(ProxyViewSelectors.httpsSwitch);
     });
 
     it("Enable HTTP proxy ", function () {

--- a/cypress/integration/views/proxy.view.ts
+++ b/cypress/integration/views/proxy.view.ts
@@ -1,5 +1,3 @@
-import { inputText } from "../../utils/utils";
-
 export enum ProxyViewSelectors {
     httpHost = '[name="httpHost"]',
     httpPort = '[name="httpPort"]',
@@ -13,18 +11,4 @@ export enum ProxyViewSelectors {
 export enum ProxyType {
     http = "http",
     https = "https",
-}
-
-export function fillHost(type: ProxyType, host: string) {
-    inputText(
-        type === ProxyType.http ? ProxyViewSelectors.httpHost : ProxyViewSelectors.httpsHost,
-        host
-    );
-}
-
-export function fillPort(type: ProxyType, port: string) {
-    inputText(
-        type === ProxyType.http ? ProxyViewSelectors.httpPort : ProxyViewSelectors.httpsPort,
-        port
-    );
 }

--- a/cypress/integration/views/proxy.view.ts
+++ b/cypress/integration/views/proxy.view.ts
@@ -1,0 +1,30 @@
+import { inputText } from "../../utils/utils";
+
+export enum ProxyViewSelectors {
+    httpHost = '[name="httpHost"]',
+    httpPort = '[name="httpPort"]',
+    httpSwitch = "#httpProxy",
+    httpsHost = '[name="httpsHost"]',
+    httpsPort = '[name="httpsPort"]',
+    httpsSwitch = "#httpsProxy",
+    portHelper = "#port-helper",
+}
+
+export enum ProxyType {
+    http = "http",
+    https = "https",
+}
+
+export function fillHost(type: ProxyType, host: string) {
+    inputText(
+        type === ProxyType.http ? ProxyViewSelectors.httpHost : ProxyViewSelectors.httpsHost,
+        host
+    );
+}
+
+export function fillPort(type: ProxyType, port: string) {
+    inputText(
+        type === ProxyType.http ? ProxyViewSelectors.httpPort : ProxyViewSelectors.httpsPort,
+        port
+    );
+}


### PR DESCRIPTION
Implemented tests to ensure that a port field cannot contain strings.
Added tests for enabling and disabling HTTP proxy with valid configuration.

Signed-off-by: Alejandro Brugarolas <abrugaro@redhat.com>

<!-- Add pull request description here -->

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
