### PR TITLE
[RFR] fix credential tests for upstream

### DIFF
--- a/cypress/integration/models/administrator/credentials/credentials.ts
+++ b/cypress/integration/models/administrator/credentials/credentials.ts
@@ -32,9 +32,9 @@ import {
 } from "../../../views/credentials.view";
 import {
     navLink,
-    closeNotification,
     confirmButton,
     cancelButton,
+    closeSuccessNotification,
 } from "../../../views/common.view";
 import { selectType } from "../../../views/credentials.view";
 import * as commonView from "../../../views/common.view";
@@ -166,6 +166,6 @@ export class Credentials {
     }
 
     protected closeSuccessNotification(): void {
-        click(closeNotification);
+        click(closeSuccessNotification);
     }
 }

--- a/cypress/integration/models/administrator/credentials/credentialsSourceControlKey.ts
+++ b/cypress/integration/models/administrator/credentials/credentialsSourceControlKey.ts
@@ -34,7 +34,7 @@ export class CredentialsSourceControlKey extends CredentialsSourceControl {
     }
 
     protected fillKeyPassphrase() {
-        inputText("[aria-label='private-key-passphrase']", this.keyPassphrase);
+        inputText("#password", this.keyPassphrase);
     }
 
     protected selectCredType() {

--- a/cypress/integration/models/administrator/proxy/proxy.ts
+++ b/cypress/integration/models/administrator/proxy/proxy.ts
@@ -93,6 +93,7 @@ export class Proxy {
 
     fillPort(port?: string): void {
         inputText(ProxyViewSelectorsByType[this.type].port, port ?? this.port);
+        cy.get(ProxyViewSelectorsByType[this.type].port).blur();
     }
 
     enable(): void {

--- a/cypress/integration/tests/administrator/credentials/maven_crud.test.ts
+++ b/cypress/integration/tests/administrator/credentials/maven_crud.test.ts
@@ -27,6 +27,7 @@ describe("Validation of Source Control Credentials", () => {
     });
 
     after("Cleaning up", () => {
+        if (hasToBeSkipped("@tier2")) return;
         mavenCredsUsername.delete();
     });
 });

--- a/cypress/integration/tests/administrator/credentials/pagination.test.ts
+++ b/cypress/integration/tests/administrator/credentials/pagination.test.ts
@@ -36,6 +36,7 @@ describe("Tag type pagination validations", { tags: "@tier3" }, function () {
     });
 
     after("Removing credentials, created earlier", () => {
+        if (hasToBeSkipped("@tier3")) return;
         deleteAllCredentials();
     });
 });

--- a/cypress/integration/tests/administrator/credentials/proxy_crud.test.ts
+++ b/cypress/integration/tests/administrator/credentials/proxy_crud.test.ts
@@ -48,6 +48,7 @@ describe("Validation of proxy credentials", () => {
     });
 
     after("Delete proxy credentials", () => {
+        if (hasToBeSkipped("@tier2")) return;
         proxyCreds.delete();
     });
 });

--- a/cypress/integration/tests/administrator/credentials/sourcecontrol_crud.test.ts
+++ b/cypress/integration/tests/administrator/credentials/sourcecontrol_crud.test.ts
@@ -77,6 +77,7 @@ describe("Validation of Source Control Credentials", () => {
     });
 
     after("Cleaning up", () => {
+        if (hasToBeSkipped("@tier1")) return;
         scCredsUsername.delete();
         scCredsKey.delete();
     });

--- a/cypress/integration/tests/administrator/proxy/proxy.enable.disable.test.ts
+++ b/cypress/integration/tests/administrator/proxy/proxy.enable.disable.test.ts
@@ -34,7 +34,7 @@ describe("Proxy operations", () => {
     it("Http Proxy port and host field validation", function () {
         httpProxy.enable();
         httpProxy.fillHost(getRandomWord(121));
-        httpProxy.fillPort("Invalid port");
+        httpProxy.fillPort("Invalid port test");
         cy.get(ProxyViewSelectors.portHelper).contains("This field is required");
         cy.get(ProxyViewSelectorsByType[httpProxy.type].hostHelper).contains(
             "This field must contain fewer than 120 characters."
@@ -47,7 +47,7 @@ describe("Proxy operations", () => {
     it("Https Proxy port and host field validation", function () {
         httpsProxy.enable();
         httpsProxy.fillHost(getRandomWord(121));
-        httpsProxy.fillPort("Invalid port");
+        httpsProxy.fillPort("Invalid port test");
         cy.get(ProxyViewSelectors.portHelper).contains("This field is required");
         cy.get(ProxyViewSelectorsByType[httpsProxy.type].hostHelper).contains(
             "This field must contain fewer than 120 characters."
@@ -88,6 +88,7 @@ describe("Proxy operations", () => {
     });
 
     after("Perform test data clean up", function () {
+        if (hasToBeSkipped("@tier2")) return;
         httpsProxyCreds.delete();
         httpProxyCreds.delete();
     });

--- a/cypress/integration/views/common.view.ts
+++ b/cypress/integration/views/common.view.ts
@@ -46,5 +46,6 @@ export const userPerspectiveMenu = ".pf-c-select__menu-item";
 export const modal = "[id^=pf-modal-part-]";
 export const navLink = ".pf-c-nav__link";
 export const closeNotification = "button[aria-label='close-notification']";
+export const closeSuccessNotification = "button[aria-label^='Close Success alert:']";
 export const divHeader = "[id^=pf-random-id-]";
 export const divBottom = "#tags-pagination-bottom";

--- a/cypress/integration/views/common.view.ts
+++ b/cypress/integration/views/common.view.ts
@@ -45,7 +45,6 @@ export const optionMenu = '[aria-label="Options menu"]';
 export const userPerspectiveMenu = ".pf-c-select__menu-item";
 export const modal = "[id^=pf-modal-part-]";
 export const navLink = ".pf-c-nav__link";
-export const closeNotification = "button[aria-label='close-notification']";
 export const closeSuccessNotification = "button[aria-label^='Close Success alert:']";
 export const divHeader = "[id^=pf-random-id-]";
 export const divBottom = "#tags-pagination-bottom";

--- a/cypress/integration/views/proxy.view.ts
+++ b/cypress/integration/views/proxy.view.ts
@@ -1,5 +1,5 @@
 export enum ProxyViewSelectors {
-    excludedList = '[aria-label="excluded"]',
+    excludedList = "#excluded",
     portHelper = "#port-helper",
 }
 


### PR DESCRIPTION
Signed-off-by: Alejandro Brugarolas <abrugaro@redhat.com>

<!-- Add pull request description here -->
1. Fix credentials tests for upstream by modifying the notification selector, now it's dynamic.

2. Make sure the 'after' method also checks for skipped tests to avoid failures in files where all tests are skipped but the  'after' method runs.
<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
