### PR TITLE
[RFR] After upgrade CSV reports validation

### DIFF
--- a/cypress/integration/tests/upgrade/after_upgrade.test.ts
+++ b/cypress/integration/tests/upgrade/after_upgrade.test.ts
@@ -20,6 +20,7 @@ import { TagType } from "../../models/developer/controls/tagtypes";
 import { Analysis } from "../../models/developer/applicationinventory/analysis";
 import { MavenConfiguration } from "../../models/administrator/repositories/maven";
 import { clearRepository } from "../../views/repository.view";
+import { GeneralConfig } from "../../models/administrator/general/generalConfig";
 
 describe("Performing post-upgrade validations", { tags: "@post-upgrade" }, () => {
     before("Login", function () {
@@ -28,6 +29,9 @@ describe("Performing post-upgrade validations", { tags: "@post-upgrade" }, () =>
 
         // Perform login
         login();
+
+        const generalConfig = GeneralConfig.getInstance();
+        generalConfig.enableDownloadCsv();
     });
 
     beforeEach("Persist session", function () {
@@ -101,8 +105,11 @@ describe("Performing post-upgrade validations", { tags: "@post-upgrade" }, () =>
 
         Analysis.open();
         exists(sourceApplicationName);
+        sourceApplication.downloadReport("CSV", false);
         exists(binaryApplicationName);
+        binaryApplication.downloadReport("CSV", false);
         exists(uploadBinaryApplicationName);
+        uploadBinaryApplication.downloadReport("CSV", false);
 
         sourceApplication.analyze();
         sourceApplication.verifyAnalysisStatus("Completed");


### PR DESCRIPTION
Added test that after upgrade old analysis results do not have CSV reports even if they are enabled in global config

<!-- Add pull request description here -->

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
