### PR TITLE
[RFR] Enabled keycloak in minikube

### DIFF
--- a/.github/install_tackle2_crd.yml
+++ b/.github/install_tackle2_crd.yml
@@ -4,6 +4,7 @@ metadata:
   name: tackle
   namespace: konveyor-tackle
 spec: {
+  feature_auth_required: true,
   hub_bucket_volume_size: 20Gi,
   maven_data_volume_size: 20Gi  
 }


### PR DESCRIPTION
<!-- Add pull request description here -->
Just added `feature_auth_required: true,` into `install_tackle2_crd.yml` to enable deployment of keycloak which is disabled by default.
<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
