### PR TITLE
[RFR] Fixed binary analysis test 

### DIFF
--- a/cypress/integration/models/migration/applicationinventory/analysis.ts
+++ b/cypress/integration/models/migration/applicationinventory/analysis.ts
@@ -322,6 +322,7 @@ export class Analysis extends Application {
                 doesExistText(type, isEnabled);
             }
         });
+        this.selectApplicationRow();
     }
 
     openAnalysisDetails() {


### PR DESCRIPTION
Fixed problem for binary analysis test and upload binary analysis test, the problem was that after downloading report, `openReport` method was clicking on analysis again.

In result right side menu was closed and report couldn't be opened. The fix is that each time after downloading report analysis is clicked again and right side menu is closing.

<!-- Add pull request description here -->

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
