### PR TITLE
[RFR] Fix manageimports sort test

### DIFF
--- a/cypress/e2e/tests/migration/applicationinventory/manageimports/sort.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/manageimports/sort.test.ts
@@ -27,7 +27,6 @@ import {
     openManageImportsPage,
     deleteApplicationTableRows,
     preservecookies,
-    hasToBeSkipped,
     deleteAppImportsTableRows,
     deleteAllBusinessServices,
 } from "../../../../../utils/utils";
@@ -50,12 +49,7 @@ describe(["@tier2"], "Manage applications import sort validations", function () 
         deleteApplicationTableRows();
         deleteAllBusinessServices();
 
-        // Create business service if not exists
-        BusinessServices.getNamesListOnPage(100).then((list) => {
-            if (!list.find((listItem) => listItem.name === businessService.name)) {
-                businessService.create();
-            }
-        });
+        businessService.create();
 
         // Open the application inventory page
         clickByText(navMenu, applicationInventory);


### PR DESCRIPTION
<!-- Add pull request description here -->
The `getNameListOnPage` method from Business Services was failing randomly due to known issues with async methods.

But there is no real need to check for the existence of a business service because, in the previous line, all business services are deleted.

Test passed in jenkins run [#260](https://main-jenkins-csb-migrationqe.apps.ocp-c1.prod.psi.redhat.com/job/mta/job/mta-ui-tests-runner/260/console)
<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
