### PR TITLE
[RFR] Fix maven repository test

### DIFF
--- a/cypress/e2e/models/administration/credentials/credentials.ts
+++ b/cypress/e2e/models/administration/credentials/credentials.ts
@@ -252,6 +252,8 @@ export class Credentials {
     }
 
     protected closeSuccessNotification(): void {
-        click(closeSuccessNotification);
+        cy.get(closeSuccessNotification, { timeout: 10 * SEC })
+            .first()
+            .click({ force: true });
     }
 }

--- a/cypress/e2e/tests/administration/repository/maven.test.ts
+++ b/cypress/e2e/tests/administration/repository/maven.test.ts
@@ -26,6 +26,7 @@ import {
     login,
     resetURL,
     writeMavenSettingsFile,
+    getRWXStatus,
 } from "../../../../utils/utils";
 import { CredentialsSourceControlUsername } from "../../../models/administration/credentials/credentialsSourceControlUsername";
 import * as data from "../../../../utils/data_utils";
@@ -139,6 +140,22 @@ describe(["@tier1"], "Test secure and insecure maven repository analysis", () =>
         MavenConfiguration.open();
         isEnabled(clearRepository, rwxEnabled);
         mavenConfiguration.clearRepository();
+    });
+
+    it("Perform RWX=true and clear repository", function () {
+        MavenConfiguration.open();
+        getRWXStatus().then((result) => {
+            const rwxDisabled = result.stdout === "false";
+            isEnabled(clearRepository, !rwxDisabled);
+
+            if (rwxDisabled) {
+                configureRWX(true);
+            }
+        });
+
+        login();
+        MavenConfiguration.open();
+        isEnabled(clearRepository, true);
     });
 
     after("Perform test data clean up", () => {

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -79,6 +79,7 @@ import { Application } from "../e2e/models/migration/applicationinventory/applic
 import { switchToggle } from "../e2e/views/reports.view";
 import { rightSideMenu } from "../e2e/views/analysis.view";
 import Chainable = Cypress.Chainable;
+import Exec = Cypress.Exec;
 
 let userName = Cypress.env("user");
 let userPassword = Cypress.env("pass");
@@ -1431,6 +1432,13 @@ export function validateTooLongInput(selector, anotherSelector?: string): void {
 // This method accepts enums or maps and returns list of keys, so you can iterate by keys
 export function enumKeys<O extends object, K extends keyof O = keyof O>(obj: O): K[] {
     return Object.keys(obj).filter((k) => Number.isNaN(+k)) as K[];
+}
+
+export function getRWXStatus(): Chainable<Exec> {
+    const tackleCr = "tackle=$(oc get tackle --all-namespaces|grep -iv name|awk '{print $2}'); ";
+    const namespace = 'namespace=$(oc get tackle --all-namespaces|grep tackle|cut -d " " -f 1); ';
+    const command = `${tackleCr} ${namespace} oc get tackle -n$namespace -o jsonpath='{.items[0].spec.rwx_supported}'`;
+    return cy.exec(command);
 }
 
 export function isRwxEnabled(): boolean {


### PR DESCRIPTION
<!-- Add pull request description here -->
This PR aims to fix the maven repository test by applying the following changes:
- Gets the current real status of RWX in runtime instead of relying on a configuration parameter.
  The RWX parameter could be change by an team-member or by another test during a job so it is not 100% safe to rely on a static confir param.

- Ensures the notification for maven credential creation is closed. 
    When creating multiple credentials, if some of the notifications are not closed, some of them can be displayed at the same time

This test passed on two different clusters in runs [#278](https://main-jenkins-csb-migrationqe.apps.ocp-c1.prod.psi.redhat.com/view/MTA/job/mta/job/mta-ui-tests-runner/278/) and [#280](https://main-jenkins-csb-migrationqe.apps.ocp-c1.prod.psi.redhat.com/view/MTA/job/mta/job/mta-ui-tests-runner/280/) but it can be affected by Refresh Token bug [#41](https://issues.redhat.com/browse/MTA-41)
<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
