### PR TITLE
[RFR] Fix double notification issue

### DIFF
--- a/cypress/e2e/models/administration/credentials/credentials.ts
+++ b/cypress/e2e/models/administration/credentials/credentials.ts
@@ -252,6 +252,8 @@ export class Credentials {
     }
 
     protected closeSuccessNotification(): void {
-        click(closeSuccessNotification);
+        cy.get(closeSuccessNotification, { timeout: 10 * SEC })
+            .first()
+            .click({ force: true });
     }
 }


### PR DESCRIPTION
<!-- Add pull request description here -->
When two credentials are created, in some cases two notifications can be displayed at the same time, causing the close function to fail.

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
