### PR TITLE
[RFR] Selectors changed for assessment's tests

### DIFF
--- a/cypress/e2e/models/migration/applicationinventory/assessment.ts
+++ b/cypress/e2e/models/migration/applicationinventory/assessment.ts
@@ -60,7 +60,9 @@ import {
 } from "../../../views/assessment.view";
 import {
     criticalityInput,
+    effortEstimateSelect,
     priorityInput,
+    proposedActionSelect,
     reviewColumnSelector,
     selectInput,
 } from "../../../views/review.view";
@@ -105,7 +107,7 @@ export class Assessment extends Application {
             const migrationActions = ["Repurchase", "Retire"];
             action = migrationActions[Math.floor(Math.random() * migrationActions.length)];
         }
-        cy.get(selectInput).eq(0).click();
+        cy.get(proposedActionSelect).eq(0).click();
         cy.contains(button, action).click();
     }
 
@@ -119,7 +121,7 @@ export class Assessment extends Application {
             const effortEstimates = ["Large", "Extra large"];
             effort = effortEstimates[Math.floor(Math.random() * effortEstimates.length)];
         }
-        cy.get(selectInput).eq(1).click();
+        cy.get(effortEstimateSelect).eq(1).click();
         cy.contains(button, effort).click();
     }
 

--- a/cypress/e2e/views/assessment.view.ts
+++ b/cypress/e2e/views/assessment.view.ts
@@ -13,8 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-export const stakeholderSelect = "input[placeholder='Select stakeholder(s)']";
-export const stakeholdergroupsSelect = "input[placeholder='Select stakeholder group(s)']";
+export const stakeholderSelect = "stakeholders-select-toggle";
+export const stakeholdergroupsSelect = "stakeholder-groups-select-toggle";
 export const questionBlock = "div[cy-data='question']";
 export const radioInput = "input[type='radio']";
 export const assessmentColumnSelector = "td[data-label='Assessment']";

--- a/cypress/e2e/views/review.view.ts
+++ b/cypress/e2e/views/review.view.ts
@@ -17,3 +17,5 @@ export const selectInput = "input[placeholder='Select']";
 export const criticalityInput = "input[name='criticality']";
 export const priorityInput = "input[name='priority']";
 export const reviewColumnSelector = "td[data-label='Review']";
+export const proposedActionSelect = "action-select-toggle";
+export const effortEstimateSelect = "effort-select-toggle";


### PR DESCRIPTION
Signed-off-by: Karishma Punwatkar <kpunwatk@redhat.com>

	modified:   cypress/e2e/models/migration/applicationinventory/assessment.ts
	modified:   cypress/e2e/views/assessment.view.ts
	modified:   cypress/e2e/views/review.view.ts

<!-- Add pull request description here -->

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
