### PR TITLE
[RFR] Wait for application table to be populated before bulk deletion

### DIFF
--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -669,6 +669,8 @@ export function verifyImportErrorMsg(errorMsg: any): void {
 
 export function deleteApplicationTableRows(currentPage = false): void {
     navigate_to_application_inventory();
+    // Wait for application table to be populated with any existing applications
+    cy.wait(2000);
     cy.get(commonView.appTable)
         .next()
         .then(($div) => {


### PR DESCRIPTION
Occasionally, applications wouldn't get deleted when  deleteApplicationTableRows() was called in the before() hook. After some investigation , I found that's because the app table was not getting populated . I added a wait call for the app table to be populated and the problem went away. 

<!-- Add pull request description here -->

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
