### PR TITLE
[RFR] Fixed RBAC custom rules failures

### DIFF
--- a/cypress/e2e/models/migration/applicationinventory/analysis.ts
+++ b/cypress/e2e/models/migration/applicationinventory/analysis.ts
@@ -380,7 +380,10 @@ export class Analysis extends Application {
 
     validateStoryPoints(): void {
         cy.get(fileName).should("contain", this.appName);
-        cy.get(reportStoryPoints).should("contain", this.storyPoints);
+        //Validating that this field contains number
+        cy.get(reportStoryPoints).should((value) => {
+            expect(Number.isNaN(parseInt(value.text(), 10))).to.eq(false);
+        });
     }
 
     validateTransactionReport(): void {


### PR DESCRIPTION
<!-- Add pull request description here -->
Fixed failing upload binary analysis with custom rules, now it will check if score field contains any number at all instead of waiting for particular number. Anyway this value is still there as it is field of the class and it can be used for comparing with windup values, etc. 
<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
