### PR TITLE
[RFR] Fix sort methods and controls jenkins failures

### DIFF
--- a/cypress/e2e/tests/migration/applicationinventory/assessment/sort.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/assessment/sort.test.ts
@@ -17,19 +17,13 @@ limitations under the License.
 
 import {
     login,
-    clickByText,
-    sortAsc,
-    sortDesc,
     verifySortAsc,
     verifySortDesc,
     getTableColumnData,
-    preservecookies,
-    hasToBeSkipped,
-    deleteApplicationTableRows,
+    clickOnSortButton,
+    deleteByList,
 } from "../../../../../utils/utils";
-import { navMenu } from "../../../../views/menu.view";
-import { applicationInventory, name, tagCount, review } from "../../../../types/constants";
-
+import { name, tagCount, review, SortType } from "../../../../types/constants";
 import * as data from "../../../../../utils/data_utils";
 import { Assessment } from "../../../../models/migration/applicationinventory/assessment";
 
@@ -39,9 +33,6 @@ describe(["@tier2"], "Application inventory sort validations", function () {
     before("Login and Create Test Data", function () {
         // Perform login
         login();
-
-        // Delete the existing applications
-        deleteApplicationTableRows();
 
         var tagsList = ["C++", "COBOL", "Java"];
         // Create multiple applications with tags
@@ -58,17 +49,9 @@ describe(["@tier2"], "Application inventory sort validations", function () {
         }
     });
 
-    beforeEach("Persist session", function () {
-        // Save the session and token cookie for maintaining one login session
-        preservecookies();
-
+    beforeEach("Interceptors", function () {
         // Interceptors
         cy.intercept("GET", "/hub/application*").as("getApplications");
-    });
-
-    after("Perform test data clean up", function () {
-        // Delete the applications created before the tests
-        deleteApplicationTableRows();
     });
 
     it("Name sort validations", function () {
@@ -80,7 +63,7 @@ describe(["@tier2"], "Application inventory sort validations", function () {
         const unsortedList = getTableColumnData(name);
 
         // Sort the application inventory by name in ascending order
-        sortAsc(name);
+        clickOnSortButton(name, SortType.ascending);
         cy.wait(2000);
 
         // Verify that the application inventory table rows are displayed in ascending order
@@ -88,36 +71,11 @@ describe(["@tier2"], "Application inventory sort validations", function () {
         verifySortAsc(afterAscSortList, unsortedList);
 
         // Sort the application inventory by name in descending order
-        sortDesc(name);
+        clickOnSortButton(name, SortType.descending);
         cy.wait(2000);
 
         // Verify that the application inventory table rows are displayed in descending order
         const afterDescSortList = getTableColumnData(name);
-        verifySortDesc(afterDescSortList, unsortedList);
-    });
-
-    it("Review sort validations", function () {
-        // Navigate to application inventory page
-        Assessment.open();
-        cy.wait("@getApplications");
-
-        // get unsorted list when page loads
-        const unsortedList = getTableColumnData(review);
-
-        // Sort the application inventory by review in ascending order
-        sortAsc(review);
-        cy.wait(2000);
-
-        // Verify that the application inventory table rows are displayed in ascending order
-        const afterAscSortList = getTableColumnData(review);
-        verifySortAsc(afterAscSortList, unsortedList);
-
-        // Sort the application inventory by name in descending order
-        sortDesc(review);
-        cy.wait(2000);
-
-        // Verify that the application inventory table rows are displayed in descending order
-        const afterDescSortList = getTableColumnData(review);
         verifySortDesc(afterDescSortList, unsortedList);
     });
 
@@ -130,7 +88,7 @@ describe(["@tier2"], "Application inventory sort validations", function () {
         const unsortedList = getTableColumnData(tagCount);
 
         // Sort the application inventory by Tag count in ascending order
-        sortAsc(tagCount);
+        clickOnSortButton(tagCount, SortType.ascending);
         cy.wait(2000);
 
         // Verify that the application inventory table rows are displayed in ascending order
@@ -138,11 +96,16 @@ describe(["@tier2"], "Application inventory sort validations", function () {
         verifySortAsc(afterAscSortList, unsortedList);
 
         // Sort the application inventory by tags in descending order
-        sortDesc(tagCount);
+        clickOnSortButton(tagCount, SortType.descending);
         cy.wait(2000);
 
         // Verify that the application inventory table rows are displayed in descending order
         const afterDescSortList = getTableColumnData(tagCount);
         verifySortDesc(afterDescSortList, unsortedList);
+    });
+
+    after("Perform test data clean up", function () {
+        // Delete the applications created before the tests
+        deleteByList(applicationsList);
     });
 });

--- a/cypress/e2e/tests/migration/applicationinventory/assessment/sort.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/assessment/sort.test.ts
@@ -31,7 +31,6 @@ var applicationsList: Array<Assessment> = [];
 
 describe(["@tier2"], "Application inventory sort validations", function () {
     before("Login and Create Test Data", function () {
-        // Perform login
         login();
 
         var tagsList = ["C++", "COBOL", "Java"];
@@ -78,6 +77,8 @@ describe(["@tier2"], "Application inventory sort validations", function () {
         const afterDescSortList = getTableColumnData(name);
         verifySortDesc(afterDescSortList, unsortedList);
     });
+
+    // Add Test case for sorting by business service
 
     it("Tag count sort validations", function () {
         // Navigate to application inventory page

--- a/cypress/e2e/tests/migration/controls/businessservices/sort.test.ts
+++ b/cypress/e2e/tests/migration/controls/businessservices/sort.test.ts
@@ -17,54 +17,37 @@ limitations under the License.
 
 import {
     login,
-    clickByText,
     sortAsc,
     sortDesc,
     verifySortAsc,
     verifySortDesc,
     getTableColumnData,
-    preservecookies,
-    hasToBeSkipped,
     createMultipleStakeholders,
     createMultipleBusinessServices,
-    deleteAllBusinessServices,
-    deleteAllStakeholders,
-    selectUserPerspective,
     deleteByList,
+    clickOnSortButton,
 } from "../../../../../utils/utils";
-import { navMenu, navTab } from "../../../../views/menu.view";
-import { controls, businessServices, name, owner } from "../../../../types/constants";
+import { name, owner } from "../../../../types/constants";
 
 import { Stakeholders } from "../../../../models/migration/controls/stakeholders";
 import { BusinessServices } from "../../../../models/migration/controls/businessservices";
+import { businessServiceTable } from "../../../../views/businessservices.view";
 
 var stakeholdersList: Array<Stakeholders> = [];
 var businessServicesList: Array<BusinessServices> = [];
 
 describe(["@tier2"], "Business services sort validations", function () {
     before("Login and Create Test Data", function () {
-        // Perform login
         login();
-        //Delete pre-existing data
-        deleteAllBusinessServices();
         // Create data
         stakeholdersList = createMultipleStakeholders(2);
         businessServicesList = createMultipleBusinessServices(2, stakeholdersList);
     });
 
     beforeEach("Persist session", function () {
-        // Save the session and token cookie for maintaining one login session
-        preservecookies();
-
         // Interceptors
         cy.intercept("POST", "/hub/business-service*").as("postBusinessService");
         cy.intercept("GET", "/hub/business-service*").as("getBusinessService");
-    });
-
-    after("Perform test data clean up", function () {
-        // Delete the bussiness services and stakeholders created before the tests
-        deleteByList(businessServicesList);
-        deleteAllStakeholders();
     });
 
     it("Name sort validations", function () {
@@ -76,7 +59,7 @@ describe(["@tier2"], "Business services sort validations", function () {
         const unsortedList = getTableColumnData(name);
 
         // Sort the business services by name in ascending order
-        sortAsc(name);
+        clickOnSortButton(name, "ascending", businessServiceTable);
         cy.wait(2000);
 
         // Verify that the business services table rows are displayed in ascending order
@@ -84,7 +67,7 @@ describe(["@tier2"], "Business services sort validations", function () {
         verifySortAsc(afterAscSortList, unsortedList);
 
         // Sort the business services by name in descending order
-        sortDesc(name);
+        clickOnSortButton(name, "descending", businessServiceTable);
         cy.wait(2000);
 
         // Verify that the business services table rows are displayed in descending order
@@ -101,7 +84,7 @@ describe(["@tier2"], "Business services sort validations", function () {
         const unsortedList = getTableColumnData(owner);
 
         // Sort the business services by owner in ascending order
-        sortAsc(owner);
+        clickOnSortButton(owner, "ascending", businessServiceTable);
         cy.wait(2000);
 
         // Verify that the business services table rows are displayed in ascending order
@@ -109,11 +92,17 @@ describe(["@tier2"], "Business services sort validations", function () {
         verifySortAsc(afterAscSortList, unsortedList);
 
         // Sort the business services by owner in descending order
-        sortDesc(owner);
+        clickOnSortButton(owner, "descending", businessServiceTable);
         cy.wait(2000);
 
         // Verify that the business services table rows are displayed in descending order
         const afterDescSortList = getTableColumnData(owner);
         verifySortDesc(afterDescSortList, unsortedList);
+    });
+
+    after("Perform test data clean up", function () {
+        // Clean up data created.
+        deleteByList(businessServicesList);
+        deleteByList(stakeholdersList);
     });
 });

--- a/cypress/e2e/tests/migration/controls/businessservices/sort.test.ts
+++ b/cypress/e2e/tests/migration/controls/businessservices/sort.test.ts
@@ -17,8 +17,6 @@ limitations under the License.
 
 import {
     login,
-    sortAsc,
-    sortDesc,
     verifySortAsc,
     verifySortDesc,
     getTableColumnData,
@@ -27,11 +25,10 @@ import {
     deleteByList,
     clickOnSortButton,
 } from "../../../../../utils/utils";
-import { name, owner } from "../../../../types/constants";
+import { SortType, name, owner } from "../../../../types/constants";
 
 import { Stakeholders } from "../../../../models/migration/controls/stakeholders";
 import { BusinessServices } from "../../../../models/migration/controls/businessservices";
-import { businessServiceTable } from "../../../../views/businessservices.view";
 
 var stakeholdersList: Array<Stakeholders> = [];
 var businessServicesList: Array<BusinessServices> = [];
@@ -59,7 +56,7 @@ describe(["@tier2"], "Business services sort validations", function () {
         const unsortedList = getTableColumnData(name);
 
         // Sort the business services by name in ascending order
-        clickOnSortButton(name, "ascending", businessServiceTable);
+        clickOnSortButton(name, SortType.ascending);
         cy.wait(2000);
 
         // Verify that the business services table rows are displayed in ascending order
@@ -67,7 +64,7 @@ describe(["@tier2"], "Business services sort validations", function () {
         verifySortAsc(afterAscSortList, unsortedList);
 
         // Sort the business services by name in descending order
-        clickOnSortButton(name, "descending", businessServiceTable);
+        clickOnSortButton(name, SortType.descending);
         cy.wait(2000);
 
         // Verify that the business services table rows are displayed in descending order
@@ -84,7 +81,7 @@ describe(["@tier2"], "Business services sort validations", function () {
         const unsortedList = getTableColumnData(owner);
 
         // Sort the business services by owner in ascending order
-        clickOnSortButton(owner, "ascending", businessServiceTable);
+        clickOnSortButton(owner, SortType.ascending);
         cy.wait(2000);
 
         // Verify that the business services table rows are displayed in ascending order
@@ -92,7 +89,7 @@ describe(["@tier2"], "Business services sort validations", function () {
         verifySortAsc(afterAscSortList, unsortedList);
 
         // Sort the business services by owner in descending order
-        clickOnSortButton(owner, "descending", businessServiceTable);
+        clickOnSortButton(owner, SortType.descending);
         cy.wait(2000);
 
         // Verify that the business services table rows are displayed in descending order

--- a/cypress/e2e/tests/migration/controls/stakeholders/filter.test.ts
+++ b/cypress/e2e/tests/migration/controls/stakeholders/filter.test.ts
@@ -19,21 +19,15 @@ import {
     login,
     clickByText,
     exists,
-    preservecookies,
     click,
     applySearchFilter,
     selectItemsPerPage,
-    hasToBeSkipped,
     createMultipleJobFunctions,
     createMultipleStakeholderGroups,
     createMultipleStakeholders,
-    selectUserPerspective,
     deleteByList,
 } from "../../../../../utils/utils";
-import { navMenu, navTab } from "../../../../views/menu.view";
 import {
-    controls,
-    stakeholders,
     button,
     tdTag,
     trTag,
@@ -42,7 +36,6 @@ import {
     jobFunction,
     group,
     clearAllFilters,
-    migration,
 } from "../../../../types/constants";
 
 import { Stakeholders } from "../../../../models/migration/controls/stakeholders";
@@ -50,7 +43,7 @@ import { Jobfunctions } from "../../../../models/migration/controls/jobfunctions
 import { Stakeholdergroups } from "../../../../models/migration/controls/stakeholdergroups";
 
 import * as commonView from "../../../../views/common.view";
-import { stakeHoldersTable } from "../../../../views/common.view";
+import { stakeHoldersTable } from "../../../../views/stakeholders.view";
 
 let stakeholdersList: Array<Stakeholders> = [];
 let jobFunctionsList: Array<Jobfunctions> = [];
@@ -59,31 +52,12 @@ let invalidSearchInput = "SomeInvalidInput";
 
 describe(["@tier2"], "Stakeholder filter validations", function () {
     before("Login and Create Test Data", function () {
-        // Prevent before hook from running, if the tag is excluded from run
-
-        // Perform login
         login();
 
         // Create multiple job functions, stakeholder groups and stakeholders
         jobFunctionsList = createMultipleJobFunctions(2);
         stakeholderGroupsList = createMultipleStakeholderGroups(2);
         stakeholdersList = createMultipleStakeholders(2, jobFunctionsList, stakeholderGroupsList);
-    });
-
-    beforeEach("Persist session", function () {
-        // Save the session and token cookie for maintaining one login session
-        preservecookies();
-
-        // Interceptors
-    });
-
-    after("Perform test data clean up", function () {
-        // Prevent before hook from running, if the tag is excluded from run
-
-        // Delete the job functions, stakeholder groups and stakeholders created before the tests
-        deleteByList(jobFunctionsList);
-        deleteByList(stakeholdersList);
-        deleteByList(stakeholderGroupsList);
     });
 
     it("MTA-881 | Email filter validations", function () {
@@ -203,5 +177,12 @@ describe(["@tier2"], "Stakeholder filter validations", function () {
         cy.get("h2").contains("No stakeholders available");
 
         clickByText(button, clearAllFilters);
+    });
+
+    after("Perform test data clean up", function () {
+        // Cleanup data
+        deleteByList(jobFunctionsList);
+        deleteByList(stakeholdersList);
+        deleteByList(stakeholderGroupsList);
     });
 });

--- a/cypress/e2e/tests/migration/controls/stakeholders/sort.test.ts
+++ b/cypress/e2e/tests/migration/controls/stakeholders/sort.test.ts
@@ -26,7 +26,7 @@ import {
     deleteByList,
     clickOnSortButton,
 } from "../../../../../utils/utils";
-import { email, displayName, jobFunction, groupCount } from "../../../../types/constants";
+import { email, displayName, jobFunction, groupCount, SortType } from "../../../../types/constants";
 
 import { Stakeholders } from "../../../../models/migration/controls/stakeholders";
 import { Jobfunctions } from "../../../../models/migration/controls/jobfunctions";
@@ -55,7 +55,7 @@ describe(["@tier2"], "Stakeholder sort validations", function () {
         const unsortedList = getTableColumnData(email);
 
         // Sort the stakeholders by email in ascending order
-        clickOnSortButton(email, "ascending", stakeHoldersTable);
+        clickOnSortButton(email, SortType.ascending, stakeHoldersTable);
         cy.wait(2000);
 
         // Verify that the stakeholder rows are displayed in ascending order
@@ -63,7 +63,7 @@ describe(["@tier2"], "Stakeholder sort validations", function () {
         verifySortAsc(afterAscSortList, unsortedList);
 
         // Sort the stakeholders by email in descending order
-        clickOnSortButton(email, "descending", stakeHoldersTable);
+        clickOnSortButton(email, SortType.descending, stakeHoldersTable);
         cy.wait(2000);
 
         // Verify that the stakeholder rows are displayed in descending order
@@ -79,7 +79,7 @@ describe(["@tier2"], "Stakeholder sort validations", function () {
         const unsortedList = getTableColumnData(displayName);
 
         // Sort the stakeholders by display name in ascending order
-        clickOnSortButton(displayName, "ascending", stakeHoldersTable);
+        clickOnSortButton(displayName, SortType.ascending, stakeHoldersTable);
         cy.wait(2000);
 
         // Verify that the stakeholder rows are displayed in ascending order
@@ -87,7 +87,7 @@ describe(["@tier2"], "Stakeholder sort validations", function () {
         verifySortAsc(afterAscSortList, unsortedList);
 
         // Sort the stakeholders by display name in descending order
-        clickOnSortButton(displayName, "descending", stakeHoldersTable);
+        clickOnSortButton(displayName, SortType.descending, stakeHoldersTable);
         cy.wait(2000);
 
         // Verify that the stakeholder rows are displayed in descending order
@@ -103,7 +103,7 @@ describe(["@tier2"], "Stakeholder sort validations", function () {
         const unsortedList = getTableColumnData(jobFunction);
 
         // Sort the stakeholders by Job function in ascending order
-        clickOnSortButton(jobFunction, "ascending", stakeHoldersTable);
+        clickOnSortButton(jobFunction, SortType.ascending, stakeHoldersTable);
         cy.wait(2000);
 
         // Verify that the stakeholder rows are displayed in ascending order
@@ -111,7 +111,7 @@ describe(["@tier2"], "Stakeholder sort validations", function () {
         verifySortAsc(afterAscSortList, unsortedList);
 
         // Sort the stakeholders by Job function in descending order
-        clickOnSortButton(jobFunction, "descending", stakeHoldersTable);
+        clickOnSortButton(jobFunction, SortType.descending, stakeHoldersTable);
         cy.wait(2000);
 
         // Verify that the stakeholder rows are displayed in descending order

--- a/cypress/e2e/tests/migration/controls/stakeholders/sort.test.ts
+++ b/cypress/e2e/tests/migration/controls/stakeholders/sort.test.ts
@@ -17,34 +17,21 @@ limitations under the License.
 
 import {
     login,
-    clickByText,
-    sortAsc,
-    sortDesc,
     verifySortAsc,
     verifySortDesc,
     getTableColumnData,
-    preservecookies,
-    hasToBeSkipped,
     createMultipleJobFunctions,
     createMultipleStakeholderGroups,
     createMultipleStakeholders,
-    selectUserPerspective,
     deleteByList,
+    clickOnSortButton,
 } from "../../../../../utils/utils";
-import { navMenu, navTab } from "../../../../views/menu.view";
-import {
-    controls,
-    email,
-    stakeholders,
-    displayName,
-    jobFunction,
-    groupCount,
-} from "../../../../types/constants";
+import { email, displayName, jobFunction, groupCount } from "../../../../types/constants";
 
 import { Stakeholders } from "../../../../models/migration/controls/stakeholders";
 import { Jobfunctions } from "../../../../models/migration/controls/jobfunctions";
 import { Stakeholdergroups } from "../../../../models/migration/controls/stakeholdergroups";
-import { fieldHeader, groupCountHeader } from "../../../../views/stakeholders.view";
+import { stakeHoldersTable } from "../../../../views/stakeholders.view";
 
 let stakeholdersList: Array<Stakeholders> = [];
 let jobFunctionsList: Array<Jobfunctions> = [];
@@ -52,7 +39,6 @@ let stakeholderGroupList: Array<Stakeholdergroups> = [];
 
 describe(["@tier2"], "Stakeholder sort validations", function () {
     before("Login and Create Test Data", function () {
-        // Perform login
         login();
 
         // Create multiple job functions, stakeholder groups and stakeholders
@@ -61,31 +47,15 @@ describe(["@tier2"], "Stakeholder sort validations", function () {
         stakeholdersList = createMultipleStakeholders(2, jobFunctionsList, stakeholderGroupList);
     });
 
-    beforeEach("Persist session", function () {
-        // Save the session and token cookie for maintaining one login session
-        preservecookies();
-
-        // Interceptors
-        cy.intercept("GET", "/hub/stakeholder*").as("getStakeholders");
-    });
-
-    after("Perform test data clean up", function () {
-        // Delete the job functions, stakeholder groups and stakeholders created before the tests
-        deleteByList(stakeholdersList);
-        deleteByList(stakeholderGroupList);
-        deleteByList(jobFunctionsList);
-    });
-
     it("Email sort validations", function () {
         // Navigate to stakeholder tab
         Stakeholders.openList();
-        cy.get("@getStakeholders");
 
         // get unsorted list when page loads
         const unsortedList = getTableColumnData(email);
 
         // Sort the stakeholders by email in ascending order
-        sortAsc(email, fieldHeader);
+        clickOnSortButton(email, "ascending", stakeHoldersTable);
         cy.wait(2000);
 
         // Verify that the stakeholder rows are displayed in ascending order
@@ -93,7 +63,7 @@ describe(["@tier2"], "Stakeholder sort validations", function () {
         verifySortAsc(afterAscSortList, unsortedList);
 
         // Sort the stakeholders by email in descending order
-        sortDesc(email, fieldHeader);
+        clickOnSortButton(email, "descending", stakeHoldersTable);
         cy.wait(2000);
 
         // Verify that the stakeholder rows are displayed in descending order
@@ -104,13 +74,12 @@ describe(["@tier2"], "Stakeholder sort validations", function () {
     it("Display name sort validations", function () {
         // Navigate to stakeholder tab
         Stakeholders.openList();
-        cy.get("@getStakeholders");
 
         // get unsorted list when page loads
         const unsortedList = getTableColumnData(displayName);
 
         // Sort the stakeholders by display name in ascending order
-        sortAsc(displayName, fieldHeader);
+        clickOnSortButton(displayName, "ascending", stakeHoldersTable);
         cy.wait(2000);
 
         // Verify that the stakeholder rows are displayed in ascending order
@@ -118,7 +87,7 @@ describe(["@tier2"], "Stakeholder sort validations", function () {
         verifySortAsc(afterAscSortList, unsortedList);
 
         // Sort the stakeholders by display name in descending order
-        sortDesc(displayName, fieldHeader);
+        clickOnSortButton(displayName, "descending", stakeHoldersTable);
         cy.wait(2000);
 
         // Verify that the stakeholder rows are displayed in descending order
@@ -129,13 +98,12 @@ describe(["@tier2"], "Stakeholder sort validations", function () {
     it("Job function sort validations", function () {
         // Navigate to stakeholder tab
         Stakeholders.openList();
-        cy.get("@getStakeholders");
 
         // get unsorted list when page loads
         const unsortedList = getTableColumnData(jobFunction);
 
         // Sort the stakeholders by Job function in ascending order
-        sortAsc(jobFunction, fieldHeader);
+        clickOnSortButton(jobFunction, "ascending", stakeHoldersTable);
         cy.wait(2000);
 
         // Verify that the stakeholder rows are displayed in ascending order
@@ -143,7 +111,7 @@ describe(["@tier2"], "Stakeholder sort validations", function () {
         verifySortAsc(afterAscSortList, unsortedList);
 
         // Sort the stakeholders by Job function in descending order
-        sortDesc(jobFunction, fieldHeader);
+        clickOnSortButton(jobFunction, "descending", stakeHoldersTable);
         cy.wait(2000);
 
         // Verify that the stakeholder rows are displayed in descending order
@@ -151,28 +119,10 @@ describe(["@tier2"], "Stakeholder sort validations", function () {
         verifySortDesc(afterDescSortList, unsortedList);
     });
 
-    it("Group sort validations", function () {
-        // Navigate to stakeholder tab
-        Stakeholders.openList();
-        cy.get("@getStakeholders");
-
-        // get unsorted list when page loads
-        const unsortedList = getTableColumnData(groupCount);
-
-        // Sort the stakeholders by group count in ascending order
-        sortAsc(groupCount, groupCountHeader);
-        cy.wait(2000);
-
-        // Verify that the stakeholder rows are displayed in ascending order
-        const afterAscSortList = getTableColumnData(groupCount);
-        verifySortAsc(afterAscSortList, unsortedList);
-
-        // Sort the stakeholders by group count in descending order
-        sortDesc(groupCount, groupCountHeader);
-        cy.wait(2000);
-
-        // Verify that the stakeholder rows are displayed in descending order
-        const afterDescSortList = getTableColumnData(groupCount);
-        verifySortDesc(afterDescSortList, unsortedList);
+    after("Perform test data clean up", function () {
+        // Delete the job functions, stakeholder groups and stakeholders created before the tests
+        deleteByList(stakeholdersList);
+        deleteByList(stakeholderGroupList);
+        deleteByList(jobFunctionsList);
     });
 });

--- a/cypress/e2e/types/constants.ts
+++ b/cypress/e2e/types/constants.ts
@@ -151,3 +151,8 @@ export enum CustomRuleType {
     Repository = "Repository",
     Manual = "Manual",
 }
+
+export enum SortType {
+    ascending = "ascending",
+    descending = "descending",
+}

--- a/cypress/e2e/views/businessservices.view.ts
+++ b/cypress/e2e/views/businessservices.view.ts
@@ -20,3 +20,4 @@ export enum buzinessServiceLabels {
     name = 'td[data-label="Name"]',
     description = 'td[data-label="Description"]',
 }
+export const businessServiceTable = "table[aria-label='main-table']";

--- a/cypress/e2e/views/businessservices.view.ts
+++ b/cypress/e2e/views/businessservices.view.ts
@@ -20,4 +20,3 @@ export enum buzinessServiceLabels {
     name = 'td[data-label="Name"]',
     description = 'td[data-label="Description"]',
 }
-export const businessServiceTable = "table[aria-label='main-table']";

--- a/cypress/e2e/views/common.view.ts
+++ b/cypress/e2e/views/common.view.ts
@@ -51,7 +51,6 @@ export const divHeader = "[id^=pf-random-id-]";
 export const divBottom = "#tags-pagination-bottom";
 export const selectFilter = "div.pf-c-toolbar__group.pf-m-toggle-group.pf-m-filter-group.pf-m-show";
 export const itemsSelectInsideDialog = "div[role='dialog'] button[aria-label='Select']";
-export const stakeHoldersTable = "table[aria-label='Stakeholders table']";
 export const nameHelperBusiness = "#business-service-name-helper";
 export const nameHelperStakeholderGroup = "#-helper";
 export const kebabMenuItem = "a.pf-c-dropdown__menu-item";

--- a/cypress/e2e/views/common.view.ts
+++ b/cypress/e2e/views/common.view.ts
@@ -54,3 +54,4 @@ export const itemsSelectInsideDialog = "div[role='dialog'] button[aria-label='Se
 export const nameHelperBusiness = "#business-service-name-helper";
 export const nameHelperStakeholderGroup = "#-helper";
 export const kebabMenuItem = "a.pf-c-dropdown__menu-item";
+export const commonTable = "table[aria-label='main-table']";

--- a/cypress/e2e/views/stakeholders.view.ts
+++ b/cypress/e2e/views/stakeholders.view.ts
@@ -23,3 +23,4 @@ export const displayNameHelper = "div[id=name-helper]";
 export const fieldHeader = ".pf-c-table__button";
 export const groupCountHeader = "thead > tr > :nth-child(5)";
 export const removeJobFunction = ".pf-c-select__toggle-clear";
+export const stakeHoldersTable = "table[aria-label='Stakeholders table']";

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -396,6 +396,25 @@ export function sortDesc(
     });
 }
 
+export function clickOnSortButton(
+    fieldName: string,
+    sortCriteria: string,
+    tableSelector: string
+): void {
+    cy.get(tableSelector)
+        .contains("th", fieldName)
+        .then(($tableHeader) => {
+            const sortButton = $tableHeader.find("button");
+            if (
+                $tableHeader.attr("aria-sort") === "none" ||
+                $tableHeader.attr("aria-sort") != sortCriteria
+            ) {
+                sortButton.trigger("click");
+            }
+            cy.wrap($tableHeader).should("have.attr", "aria-sort", sortCriteria);
+        });
+}
+
 export function sortAscCopyAssessmentTable(sortCriteria: string): void {
     cy.get(`.pf-m-compact > thead > tr > th[data-label="${sortCriteria}"]`).then(($tableHeader) => {
         if (

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -399,7 +399,7 @@ export function sortDesc(
 export function clickOnSortButton(
     fieldName: string,
     sortCriteria: string,
-    tableSelector: string
+    tableSelector: string = commonView.commonTable
 ): void {
     cy.get(tableSelector)
         .contains("th", fieldName)


### PR DESCRIPTION
1) SortAsc and sortDesc methods to be replaced by clickonSortButton() method
2) Sort by group count not relevant anymore in stakeholder - removed test .
3) Clean up unused imports and presevecookies methods.