### PR TITLE
[RFR] Reduce memory consumption

### DIFF
--- a/cypress/e2e/models/migration/applicationinventory/analysis.ts
+++ b/cypress/e2e/models/migration/applicationinventory/analysis.ts
@@ -295,12 +295,13 @@ export class Analysis extends Application {
     }
 
     verifyAnalysisStatus(status) {
-        cy.get(tdTag)
-            .contains(this.name)
-            .closest(trTag)
+        cy.log(`Verifying analysis status, expecting ${status}`);
+        cy.get(tdTag, { log: false })
+            .contains(this.name, { log: false })
+            .closest(trTag, { log: false })
             .within(() => {
-                cy.get(analysisColumn)
-                    .find("div > div:nth-child(2)", { timeout: 3600000 }) // 1h
+                cy.get(analysisColumn, { log: false })
+                    .find("div > div:nth-child(2)", { timeout: 3600000, log: false }) // 1h
                     .should("not.have.text", AnalysisStatuses.notStarted)
                     .and("not.have.text", AnalysisStatuses.scheduled)
                     .and("not.have.text", AnalysisStatuses.inProgress)

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -41,3 +41,15 @@ require("cypress-xpath"); // Refer - https://www.npmjs.com/package/cypress-xpath
 // load and register the grep feature
 // https://github.com/bahmutov/cypress-grep
 require("cypress-grep")();
+
+/** Hide XHR logs line */
+// TODO: Improve by implementing a configuration parameter
+const app = window.top;
+
+if (app && !app.document.head.querySelector("[data-hide-command-log-request]")) {
+    const style = app.document.createElement("style");
+    style.innerHTML = ".command-name-request, .command-name-xhr { display: none }";
+    style.setAttribute("data-hide-command-log-request", "");
+
+    app.document.head.appendChild(style);
+}

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -94,9 +94,13 @@ const tackleUiUrl = Cypress.env("tackleUrl");
 const { _ } = Cypress;
 
 export function inputText(fieldId: string, text: any): void {
-    cy.get(fieldId).click().focused().clear();
-    cy.wait(200);
-    cy.get(fieldId).clear().type(text);
+    cy.log(`Type ${text} in ${fieldId}`);
+    cy.get(fieldId, { log: false })
+        .click({ log: false })
+        .focused({ log: false })
+        .clear({ log: false });
+    cy.wait(200, { log: false });
+    cy.get(fieldId, { log: false }).clear({ log: false }).type(text, { log: false });
 }
 
 export function clearInput(fieldID: string): void {
@@ -104,13 +108,18 @@ export function clearInput(fieldID: string): void {
 }
 
 export function clickByText(fieldId: string, buttonText: string, isForced = true): void {
+    cy.log(`Click by text, id: ${fieldId}, text: ${buttonText}`);
     // https://github.com/cypress-io/cypress/issues/2000#issuecomment-561468114
-    cy.contains(fieldId, buttonText, { timeout: 120 * SEC }).click({ force: isForced });
-    cy.wait(SEC);
+    cy.contains(fieldId, buttonText, { timeout: 60 * SEC, log: false }).click({
+        force: isForced,
+        log: false,
+    });
+    cy.wait(SEC, { log: false });
 }
 
 export function click(fieldId: string, isForced = true): void {
-    cy.get(fieldId, { timeout: 120 * SEC }).click({ force: isForced });
+    cy.log(`Click ${fieldId}`);
+    cy.get(fieldId, { log: false, timeout: 60 * SEC }).click({ log: false, force: isForced });
 }
 
 export function submitForm(): void {
@@ -134,9 +143,10 @@ export function login(username?, password?: string, firstLogin = false): Chainab
     const sessionId = (username ?? "login") + (firstLogin ? "FirstLogin" : "");
 
     return cy.session(sessionId, () => {
+        cy.log("Login in");
         cy.visit(Cypress.env("tackleUrl"), { timeout: 120 * SEC });
         cy.wait(5000);
-        cy.get("h1", { timeout: 120 * SEC }).then(($title) => {
+        cy.get("h1", { timeout: 120 * SEC, log: false }).then(($title) => {
             if ($title.text().toString().trim() !== "Sign in to your account") {
                 return;
             }
@@ -160,7 +170,7 @@ export function login(username?, password?: string, firstLogin = false): Chainab
 
         updatePassword();
         cy.get("#main-content-page-layout-horizontal-nav").within(() => {
-            cy.get("h1", { timeout: 15 * SEC }).contains("Application inventory");
+            cy.get("h1", { timeout: 15 * SEC, log: false }).contains("Application inventory");
         });
     });
 }
@@ -197,13 +207,17 @@ export function resetURL(): void {
 }
 
 export function selectItemsPerPage(items: number): void {
-    cy.get(commonView.itemsPerPageMenu, { timeout: 120 * SEC })
-        .find(commonView.itemsPerPageToggleButton)
+    cy.log(`Select ${items} per page`);
+    cy.get(commonView.itemsPerPageMenu, { timeout: 60 * SEC, log: false })
+        .find(commonView.itemsPerPageToggleButton, { log: false })
         .then(($toggleBtn) => {
             if (!$toggleBtn.eq(0).is(":disabled")) {
                 $toggleBtn.eq(0).trigger("click");
-                cy.get(commonView.itemsPerPageMenuOptions);
-                cy.get(`li > button[data-action="per-page-${items}"]`).click({ force: true });
+                cy.get(commonView.itemsPerPageMenuOptions, { log: false });
+                cy.get(`li > button[data-action="per-page-${items}"]`, { log: false }).click({
+                    force: true,
+                    log: false,
+                });
                 cy.wait(2 * SEC);
             }
         });

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -93,33 +93,41 @@ let userPassword = Cypress.env("pass");
 const tackleUiUrl = Cypress.env("tackleUrl");
 const { _ } = Cypress;
 
-export function inputText(fieldId: string, text: any): void {
-    cy.log(`Type ${text} in ${fieldId}`);
-    cy.get(fieldId, { log: false })
-        .click({ log: false })
-        .focused({ log: false })
-        .clear({ log: false });
-    cy.wait(200, { log: false });
-    cy.get(fieldId, { log: false }).clear({ log: false }).type(text, { log: false });
+export function inputText(fieldId: string, text: any, log = false): void {
+    if (!log) {
+        cy.log(`Type ${text} in ${fieldId}`);
+    }
+    cy.get(fieldId, { log }).click({ log }).focused({ log }).clear({ log });
+    cy.wait(200, { log });
+    cy.get(fieldId, { log }).clear({ log }).type(text, { log });
 }
 
 export function clearInput(fieldID: string): void {
     cy.get(fieldID).clear();
 }
 
-export function clickByText(fieldId: string, buttonText: string, isForced = true): void {
-    cy.log(`Click by text, id: ${fieldId}, text: ${buttonText}`);
+export function clickByText(
+    fieldId: string,
+    buttonText: string,
+    isForced = true,
+    log = false
+): void {
+    if (!log) {
+        cy.log(`Click by text, id: ${fieldId}, text: ${buttonText}`);
+    }
     // https://github.com/cypress-io/cypress/issues/2000#issuecomment-561468114
-    cy.contains(fieldId, buttonText, { timeout: 60 * SEC, log: false }).click({
+    cy.contains(fieldId, buttonText, { timeout: 60 * SEC, log }).click({
         force: isForced,
-        log: false,
+        log,
     });
-    cy.wait(SEC, { log: false });
+    cy.wait(SEC, { log });
 }
 
-export function click(fieldId: string, isForced = true): void {
-    cy.log(`Click ${fieldId}`);
-    cy.get(fieldId, { log: false, timeout: 60 * SEC }).click({ log: false, force: isForced });
+export function click(fieldId: string, isForced = true, log = false): void {
+    if (!log) {
+        cy.log(`Click ${fieldId}`);
+    }
+    cy.get(fieldId, { log, timeout: 60 * SEC }).click({ log, force: isForced });
 }
 
 export function submitForm(): void {


### PR DESCRIPTION
<!-- Add pull request description here -->
One of the main problems that caused the browser to crash when running multiple tests was the large number of log lines generated by each operation we were performing.

Each log line represented a different element in the DOM, and it was leading to an increase in the browser's memory consumption until it eventually crashed

To address this issue, I changed some of the common functions in order to minimize the number of logs they generate, while still providing enough information for debugging failures with just a screenshot.

I implemented this as a default parameter, allowing us to quickly enable all the logs for local debugging when needed.

Additionally, I created a small function to hide all XHR request logs that were being generated.

Finally, I reduced the timeout of certain functions because we typically don't want to wait up to 2 minutes for something to fail. I have reduced it to 1 minute, but I believe it can be further reduced.

Here's how we were seeing the logs until now:

![image](https://github.com/konveyor/tackle-ui-tests/assets/117646518/6158ebfe-980d-4813-97ac-bc81d7f5d60f)


And here's a screenshot of how are we going to see the logs from now on.

![image](https://github.com/konveyor/tackle-ui-tests/assets/117646518/f8b81727-d9fb-4257-8264-859cb9f9b4c6)

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
