### PR TITLE
[RFR] Export different issue types

### DIFF
--- a/cypress/e2e/models/migration/migration-waves/migration-wave.ts
+++ b/cypress/e2e/models/migration/migration-waves/migration-wave.ts
@@ -138,6 +138,7 @@ export class MigrationWave {
         cy.contains(manageApplications).click();
         cy.get(itemsSelectInsideDialog).click();
         cy.contains(button, selectNone).click();
+        selectItemsPerPage(100);
 
         this.applications.forEach((app) => {
             cy.get(tdTag)

--- a/cypress/e2e/tests/migration/migration-waves/export.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/export.test.ts
@@ -23,7 +23,7 @@ let projectName = "";
 /**
  * This test suite contains tests that are co-dependent, so they won't pass if they're executed separately
  */
-describe.only(["@tier1"], "Export Migration Wave to Issue Manager", function () {
+describe(["@tier1"], "Export Migration Wave to Issue Manager", function () {
     before("Create test data", function () {
         login();
 

--- a/cypress/e2e/tests/migration/migration-waves/export.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/export.test.ts
@@ -19,11 +19,11 @@ const applications: Assessment[] = [];
 const wavesMap = {};
 let projectName = "";
 
-// Automates Polarion TC 340
+// Automates Polarion TC 340, 359, 360 and 361 for Jira Cloud
 /**
  * This test suite contains tests that are co-dependent, so they won't pass if they're executed separately
  */
-describe(["@tier1"], "Export Migration Wave to Issue Manager", function () {
+describe.only(["@tier1"], "Export Migration Wave to Issue Manager", function () {
     before("Create test data", function () {
         login();
 
@@ -79,8 +79,9 @@ describe(["@tier1"], "Export Migration Wave to Issue Manager", function () {
     });
 
     Object.values(JiraIssueTypes).forEach((issueType) => {
-        it(`Assert exports for ${issueType}`, function () {
-            cy.wait(35 * SEC); // Enough time to create both tasks and for them to be available in the Jira API
+        const markBug = issueType === "Subtask" ? "BUG MTA-870 | " : "";
+        it(`${markBug} Assert exports for ${issueType}`, function () {
+            cy.wait(30 * SEC); // Enough time to create both tasks and for them to be available in the Jira API
             jiraCloudInstance.getIssues(projectName).then((issues: JiraIssue[]) => {
                 const waveIssues = issues.filter((issue) => {
                     return (
@@ -88,7 +89,8 @@ describe(["@tier1"], "Export Migration Wave to Issue Manager", function () {
                             issue.fields.summary.includes(
                                 wavesMap[issueType].applications[1].name
                             )) &&
-                        issue.fields.issuetype.untranslatedName === (issueType as string)
+                        issue.fields.issuetype.name.toUpperCase() ===
+                            (issueType as string).toUpperCase()
                     );
                 });
 
@@ -98,7 +100,6 @@ describe(["@tier1"], "Export Migration Wave to Issue Manager", function () {
             });
         });
     });
-
     after("Clear test data", function () {
         Object.values(wavesMap).forEach((wave: MigrationWave) => wave.delete());
         applications.forEach((app) => app.delete());

--- a/cypress/e2e/tests/migration/migration-waves/export.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/export.test.ts
@@ -1,5 +1,5 @@
 import { createMultipleApplications, login } from "../../../../utils/utils";
-import { CredentialType, JiraType, SEC } from "../../../types/constants";
+import { CredentialType, JiraIssueTypes, JiraType, SEC } from "../../../types/constants";
 import * as data from "../../../../utils/data_utils";
 import { MigrationWave } from "../../../models/migration/migration-waves/migration-wave";
 import { Assessment } from "../../../models/migration/applicationinventory/assessment";
@@ -13,82 +13,93 @@ now.setDate(now.getDate() + 1);
 const end = new Date(now.getTime());
 end.setFullYear(end.getFullYear() + 1);
 
-let applications: Assessment[];
-let migrationWave: MigrationWave;
-let jiraInstance: Jira;
-let jiraCredentials: JiraCredentials;
+let jiraCloudCredentials: JiraCredentials;
+let jiraCloudInstance: Jira;
+const applications: Assessment[] = [];
+const wavesMap = {};
+let projectName = "";
 
 // Automates Polarion TC 340
+/**
+ * This test suite contains tests that are co-dependent, so they won't pass if they're executed separately
+ */
 describe(["@tier1"], "Export Migration Wave to Issue Manager", function () {
     before("Create test data", function () {
         login();
-        applications = createMultipleApplications(2);
 
-        migrationWave = new MigrationWave(
-            data.getRandomWord(8),
-            now,
-            end,
-            null,
-            null,
-            applications
+        jiraCloudCredentials = new JiraCredentials(
+            data.getJiraCredentialData(CredentialType.jiraBasic, true)
         );
-        migrationWave.create();
+        jiraCloudCredentials.create();
 
-        jiraCredentials = new JiraCredentials(
-            data.getRandomCredentialsData(CredentialType.jiraBasic, null, true)
-        );
-        jiraCredentials.create();
-
-        jiraInstance = new Jira({
-            name: data.getRandomWord(5),
-            url: Cypress.env("jira_atlassian_cloud_url"),
-            credential: jiraCredentials,
-            type: JiraType.cloud,
-        });
-        jiraInstance.create();
+        jiraCloudInstance = new Jira(data.getJiraConnectionData(jiraCloudCredentials, false, true));
+        jiraCloudInstance.create();
     });
 
-    it("Export issues to Jira", function () {
-        let projectName = "";
+    Object.values(JiraIssueTypes).forEach((issueType) => {
+        it(`Create wave to export as ${issueType}`, function () {
+            const apps = createMultipleApplications(2);
+            applications.push(...apps);
 
-        jiraInstance
-            .getProject()
-            .then((project) => {
-                expect(!!project).to.eq(true);
+            const migrationWave = new MigrationWave(
+                data.getRandomWord(8),
+                now,
+                end,
+                null,
+                null,
+                apps
+            );
+            migrationWave.create();
+            wavesMap[issueType] = migrationWave;
+        });
+    });
 
-                projectName = project.name;
+    Object.values(JiraIssueTypes).forEach((issueType) => {
+        it(`Export wave as ${issueType} to Jira`, function () {
+            jiraCloudInstance
+                .getProject()
+                .then((project) => {
+                    expect(!!project).to.eq(true);
 
-                return jiraInstance.getIssueType("Task");
-            })
-            .then((task) => {
-                expect(!!task).to.eq(true);
+                    projectName = project.name;
 
-                migrationWave.exportToIssueManager(
-                    JiraType.cloud,
-                    jiraInstance.name,
-                    projectName,
-                    task.untranslatedName
-                );
-            })
-            .then((_) => {
-                cy.wait(35 * SEC); // Enough time to create both tasks and for them to be available in the Jira API
-                return jiraInstance.getIssues(projectName);
-            })
-            .then((issues: JiraIssue[]) => {
-                expect(
-                    migrationWave.applications.every((app) =>
-                        issues.find((issue) => issue.fields.summary.includes(app.name))
-                    )
-                ).to.eq(true);
+                    return jiraCloudInstance.getIssueType(issueType);
+                })
+                .then((issue) => {
+                    expect(!!issue).to.eq(true);
 
-                jiraInstance.deleteIssues(issues.map((issue) => issue.id));
+                    wavesMap[issueType].exportToIssueManager(
+                        JiraType.cloud,
+                        jiraCloudInstance.name,
+                        projectName,
+                        issue.untranslatedName
+                    );
+                });
+        });
+    });
+
+    Object.values(JiraIssueTypes).forEach((issueType) => {
+        it(`Assert exports for ${issueType}`, function () {
+            cy.wait(35 * SEC); // Enough time to create both tasks and for them to be available in the Jira API
+            jiraCloudInstance.getIssues(projectName).then((issues: JiraIssue[]) => {
+                const waveIssues = issues.filter((issue) => {
+                    return (
+                        issue.fields.summary.includes(wavesMap[issueType].applications[0].name) ||
+                        issue.fields.summary.includes(wavesMap[issueType].applications[1].name)
+                    );
+                });
+
+                expect(waveIssues).to.have.length(2);
+
+                jiraCloudInstance.deleteIssues(waveIssues.map((issue) => issue.id));
             });
+        });
     });
 
     after("Clear test data", function () {
-        migrationWave.delete();
-        jiraInstance.delete();
-        jiraCredentials.delete();
+        Object.values(wavesMap).forEach((wave: MigrationWave) => wave.delete());
         applications.forEach((app) => app.delete());
+        jiraCloudInstance.delete();
+        jiraCloudCredentials.delete();
     });
 });

--- a/cypress/e2e/tests/migration/migration-waves/export.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/export.test.ts
@@ -84,14 +84,17 @@ describe(["@tier1"], "Export Migration Wave to Issue Manager", function () {
             jiraCloudInstance.getIssues(projectName).then((issues: JiraIssue[]) => {
                 const waveIssues = issues.filter((issue) => {
                     return (
-                        issue.fields.summary.includes(wavesMap[issueType].applications[0].name) ||
-                        issue.fields.summary.includes(wavesMap[issueType].applications[1].name)
+                        (issue.fields.summary.includes(wavesMap[issueType].applications[0].name) ||
+                            issue.fields.summary.includes(
+                                wavesMap[issueType].applications[1].name
+                            )) &&
+                        issue.fields.issuetype.untranslatedName === (issueType as string)
                     );
                 });
 
-                expect(waveIssues).to.have.length(2);
-
                 jiraCloudInstance.deleteIssues(waveIssues.map((issue) => issue.id));
+
+                expect(waveIssues).to.have.length(2);
             });
         });
     });

--- a/cypress/e2e/tests/migration/migration-waves/export_to_jira_cloud.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/export_to_jira_cloud.test.ts
@@ -23,7 +23,7 @@ let projectName = "";
 /**
  * This test suite contains tests that are co-dependent, so they won't pass if they're executed separately
  */
-describe(["@tier1"], "Export Migration Wave to Issue Manager", function () {
+describe(["@tier1"], "Export Migration Wave to Jira Cloud", function () {
     before("Create test data", function () {
         login();
 

--- a/cypress/e2e/types/constants.ts
+++ b/cypress/e2e/types/constants.ts
@@ -125,6 +125,13 @@ export enum JiraType {
     server = "Jira Server/Datacenter",
 }
 
+export enum JiraIssueTypes {
+    task = "Task",
+    subtask = "Subtask",
+    epic = "Epic",
+    story = "Story",
+}
+
 export enum UserCredentials {
     usernamePassword = "Username/Password",
     sourcePrivateKey = "Source PrivateKey",


### PR DESCRIPTION
<!-- Add pull request description here -->
Automates Polarion TC 340, 359, 360 and 361 for Jira Cloud
This suite generates dynamic test cases for Jira cloud waves export as different issue types.
Please note that these tests are co-dependant, which means that the test cases cannot be executed individually.
For a matter of readability, Jira Datacenter export tests will have to be automated in a different file.

Jenkins run: [#606](https://main-jenkins-csb-migrationqe.apps.ocp-c1.prod.psi.redhat.com/job/mta/job/mta-ui-tests-runner/606/console)

@sshveta can you please review this PR? Thanks

![image](https://github.com/konveyor/tackle-ui-tests/assets/117646518/cee5891d-aed1-406c-ba81-4c00c057eaaf)

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
