### PR TITLE
[RFR] fix filter.test in migration waves

### DIFF
--- a/cypress/e2e/tests/migration/migration-waves/filter.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/filter.test.ts
@@ -24,6 +24,7 @@ import { button, name, clearAllFilters, SEC } from "../../../types/constants";
 
 import * as data from "../../../../utils/data_utils";
 import { MigrationWave } from "../../../models/migration/migration-waves/migration-wave";
+import { MigrationWaveView } from "../../../views/migration-wave.view";
 
 let migrationWavesList: Array<MigrationWave> = [];
 //Automates Polarion TC 343
@@ -59,7 +60,9 @@ describe(["@tier2"], "Migration waves filter validations", function () {
         applySearchFilter(name, String(data.getRandomNumber()));
 
         // Assert that no search results are found
-        cy.get("td").should("not.exist");
+        cy.get(MigrationWaveView.migrationWavesTable)
+            .find("h2")
+            .should("contain", "No migration waves available");
         clickByText(button, clearAllFilters);
     });
 


### PR DESCRIPTION
Fixed filter test - now the test finds relevant h2 inside the migration waves table and validate that nothing is shown

<!-- Add pull request description here -->

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
