### PR TITLE
[WIP] Add export to datacenter test

### DIFF
--- a/cypress/e2e/types/constants.ts
+++ b/cypress/e2e/types/constants.ts
@@ -127,7 +127,6 @@ export enum JiraType {
 
 export enum JiraIssueTypes {
     task = "Task",
-    subtask = "Subtask",
     epic = "Epic",
     story = "Story",
 }

--- a/cypress/e2e/types/constants.ts
+++ b/cypress/e2e/types/constants.ts
@@ -127,6 +127,7 @@ export enum JiraType {
 
 export enum JiraIssueTypes {
     task = "Task",
+    bug = "Bug",
     epic = "Epic",
     story = "Story",
 }


### PR DESCRIPTION
<!-- Add pull request description here -->
This PR adds the suite for testing migration waves exports to Jira Datacenter.
It also adds new supported Issue types.

This suite is very similar to the Jira cloud suite, even if both suites can be created in the same file, it would make the code very hard to read and a failure in a Jira cloud test could affect a Jira Datacenter test. That's why both suite are separated in different files.

Passed in Jenkins run [701](https://main-jenkins-csb-migrationqe.apps.ocp-c1.prod.psi.redhat.com/view/MTA/job/mta/job/mta-ui-tests-runner/701/console)

![image](https://github.com/konveyor/tackle-ui-tests/assets/117646518/aebc09cd-d8ef-4f3c-b677-76555b6253ca)

@sshveta could you review this PE please?
<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
