### PR TITLE
[RFR] fixed field validation test and updated migration wave delete method

### DIFF
--- a/cypress/e2e/models/migration/migration-waves/migration-wave.ts
+++ b/cypress/e2e/models/migration/migration-waves/migration-wave.ts
@@ -260,7 +260,7 @@ export class MigrationWave {
         cy.get("button").contains(stakeHolderGroupName).click();
     }
 
-    private formatDate(date: Date): string {
+    static formatDateMMddYYYY(date: Date): string {
         const day = String(date.getDate()).padStart(2, "0");
         const month = String(date.getMonth() + 1).padStart(2, "0"); //January is 0!
         const year = date.getFullYear();
@@ -269,12 +269,8 @@ export class MigrationWave {
     }
 
     public expandActionsMenu() {
-        let targetName: string | undefined;
-        let targetStartDate: string | undefined;
-        let targetEndDate: string | undefined;
-
         if (this.name) {
-            targetName = this.name;
+            const targetName = this.name;
             cy.contains(targetName)
                 .parents("tr")
                 .within(() => {
@@ -284,30 +280,24 @@ export class MigrationWave {
                         }
                     });
                 });
-        } else if (this.startDate && this.endDate) {
-            targetStartDate = this.startDate ? this.formatDate(this.startDate) : undefined;
-            targetEndDate = this.endDate ? this.formatDate(this.endDate) : undefined;
-            if (targetStartDate && targetEndDate) {
-                cy.get("tbody tr").each(($row) => {
-                    const startCell = $row.find('td[data-label="Start date"]').text().trim();
-                    const endCell = $row.find('td[data-label="End date"]').text().trim();
+        } else {
+            const targetStartDate = MigrationWave.formatDateMMddYYYY(this.startDate);
+            const targetEndDate = MigrationWave.formatDateMMddYYYY(this.endDate);
 
-                    if (startCell === targetStartDate && endCell === targetEndDate) {
-                        cy.wrap($row)
-                            .find(MigrationWaveView.actionsButton)
-                            .then(($btn) => {
-                                if ($btn.attr("aria-expanded") === "false") {
-                                    $btn.trigger("click");
-                                }
-                            });
-                    }
-                });
-            } else {
-                console.error(
-                    "No valid target for cy.contains. Please provide a name or valid date range."
-                );
-                return;
-            }
+            cy.get("tbody tr").each(($row) => {
+                const startCell = $row.find('td[data-label="Start date"]').text().trim();
+                const endCell = $row.find('td[data-label="End date"]').text().trim();
+
+                if (startCell === targetStartDate && endCell === targetEndDate) {
+                    cy.wrap($row)
+                        .find(MigrationWaveView.actionsButton)
+                        .then(($btn) => {
+                            if ($btn.attr("aria-expanded") === "false") {
+                                $btn.trigger("click");
+                            }
+                        });
+                }
+            });
         }
     }
 

--- a/cypress/e2e/tests/migration/migration-waves/field_validation.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/field_validation.test.ts
@@ -66,7 +66,7 @@ describe(["@tier1"], "Migration Waves Validations", () => {
         cy.get(MigrationWaveView.submitButton).should("be.disabled");
         const now = new Date();
 
-        let options = { year: "numeric", month: "long", day: "numeric" } as const;
+        const options = { year: "numeric", month: "long", day: "numeric" } as const;
         //used to get a date format such as "9 August 2023"
         const nowDateLabel = new Intl.DateTimeFormat("en-GB", options).format(now);
 
@@ -74,17 +74,17 @@ describe(["@tier1"], "Migration Waves Validations", () => {
         const tomorrow = new Date(now);
         tomorrow.setDate(now.getDate() + 1);
 
-        const DateTomorrowLabel = new Intl.DateTimeFormat("en-GB", options).format(tomorrow);
+        const dateTomorrowLabel = new Intl.DateTimeFormat("en-GB", options).format(tomorrow);
         // Start date should be greater than actual date
         cy.get(`button[aria-label="${nowDateLabel}"]`).should("be.disabled");
-        cy.get(`button[aria-label="${DateTomorrowLabel}"]`).should("be.enabled").click();
+        cy.get(`button[aria-label="${dateTomorrowLabel}"]`).should("be.enabled").click();
 
         cy.get(MigrationWaveView.endDateInput).next("button").click();
         // End date should be greater than start date
-        cy.get(`button[aria-label="${DateTomorrowLabel}"]`).should("be.disabled");
+        cy.get(`button[aria-label="${dateTomorrowLabel}"]`).should("be.disabled");
         const dayAfterTomorrow = new Date(now);
         dayAfterTomorrow.setDate(now.getDate() + 2);
-        let dayAfterTomorrowLabel = new Intl.DateTimeFormat("en-GB", options).format(
+        const dayAfterTomorrowLabel = new Intl.DateTimeFormat("en-GB", options).format(
             dayAfterTomorrow
         );
         cy.get(`button[aria-label="${dayAfterTomorrowLabel}"]`).should("be.enabled").click();

--- a/cypress/e2e/tests/migration/migration-waves/field_validation.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/field_validation.test.ts
@@ -64,38 +64,30 @@ describe(["@tier1"], "Migration Waves Validations", () => {
         MigrationWave.openNewForm();
         MigrationWave.fillName(data.getRandomWord(5));
         cy.get(MigrationWaveView.submitButton).should("be.disabled");
-
         const now = new Date();
+
+        let options = { year: "numeric", month: "long", day: "numeric" } as const;
+        //used to get a date format such as "9 August 2023"
+        const nowDateLabel = new Intl.DateTimeFormat("en-GB", options).format(now);
+
         cy.get(MigrationWaveView.startDateInput).next("button").click();
         const tomorrow = new Date(now);
         tomorrow.setDate(now.getDate() + 1);
 
-        const tomorrowRegex = new RegExp("^" + tomorrow.getDate() + "$");
+        const DateTomorrowLabel = new Intl.DateTimeFormat("en-GB", options).format(tomorrow);
         // Start date should be greater than actual date
-        cy.contains("button", new RegExp("^" + now.getDate() + "$")).should("be.disabled");
-        cy.get("button")
-            .filter((index, element) => {
-                return (
-                    element.className === "pf-c-calendar-month__date" &&
-                    element.textContent.trim() === tomorrow.getDate().toString()
-                );
-            })
-            .should("be.enabled")
-            .click();
+        cy.get(`button[aria-label="${nowDateLabel}"]`).should("be.disabled");
+        cy.get(`button[aria-label="${DateTomorrowLabel}"]`).should("be.enabled").click();
+
         cy.get(MigrationWaveView.endDateInput).next("button").click();
         // End date should be greater than start date
-        cy.contains("button", tomorrowRegex).should("be.disabled");
+        cy.get(`button[aria-label="${DateTomorrowLabel}"]`).should("be.disabled");
         const dayAfterTomorrow = new Date(now);
         dayAfterTomorrow.setDate(now.getDate() + 2);
-        cy.get("button")
-            .filter((index, element) => {
-                return (
-                    element.className === "pf-c-calendar-month__date" &&
-                    element.textContent.trim() === dayAfterTomorrow.getDate().toString()
-                );
-            })
-            .should("be.enabled")
-            .click();
+        let dayAfterTomorrowLabel = new Intl.DateTimeFormat("en-GB", options).format(
+            dayAfterTomorrow
+        );
+        cy.get(`button[aria-label="${dayAfterTomorrowLabel}"]`).should("be.enabled").click();
 
         cy.get(MigrationWaveView.submitButton).should("be.enabled");
         cy.get(cancelButton).click();

--- a/cypress/e2e/tests/migration/migration-waves/field_validation.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/field_validation.test.ts
@@ -67,21 +67,33 @@ describe(["@tier1"], "Migration Waves Validations", () => {
 
         const now = new Date();
         cy.get(MigrationWaveView.startDateInput).next("button").click();
-        const tomorrow = new RegExp("^" + (now.getDate() + 1) + "$");
+        const tomorrow = new Date(now);
+        tomorrow.setDate(now.getDate() + 1);
+
+        const tomorrowRegex = new RegExp("^" + tomorrow.getDate() + "$");
         // Start date should be greater than actual date
         cy.contains("button", new RegExp("^" + now.getDate() + "$")).should("be.disabled");
-        cy.get("td:not(.pf-m-adjacent-month)")
-            .contains("button.pf-c-calendar-month__date", tomorrow)
+        cy.get("button")
+            .filter((index, element) => {
+                return (
+                    element.className === "pf-c-calendar-month__date" &&
+                    element.textContent.trim() === tomorrow.getDate().toString()
+                );
+            })
             .should("be.enabled")
             .click();
         cy.get(MigrationWaveView.endDateInput).next("button").click();
         // End date should be greater than start date
-        cy.contains("button", tomorrow).should("be.disabled");
-        cy.get("td:not(.pf-m-adjacent-month)")
-            .contains(
-                "button.pf-c-calendar-month__date",
-                new RegExp("^" + (now.getDate() + 2) + "$")
-            )
+        cy.contains("button", tomorrowRegex).should("be.disabled");
+        const dayAfterTomorrow = new Date(now);
+        dayAfterTomorrow.setDate(now.getDate() + 2);
+        cy.get("button")
+            .filter((index, element) => {
+                return (
+                    element.className === "pf-c-calendar-month__date" &&
+                    element.textContent.trim() === dayAfterTomorrow.getDate().toString()
+                );
+            })
             .should("be.enabled")
             .click();
 
@@ -103,6 +115,8 @@ describe(["@tier1"], "Migration Waves Validations", () => {
         migrationWave3.create();
         migrationWave3.create();
         checkSuccessAlert(commonView.duplicateNameWarning, duplicateMigrationWaveError);
+        migrationWavesList.push(migrationWave3);
+
         //migrationwave3 name is null, so it can't be deleted by list
         deleteByList(migrationWavesList);
     });


### PR DESCRIPTION
updated delete method in migration wave to also delete migration waves with no name based on startDate and endDate - 
fixed field validation test in migration wave by:
it was selecting incorrect days in dates such as "32" - fixed the regex for it
 fixed method selectDateFromDatePicker as it was selecting incorrect dates which caused delete by date to fail

Jenkins run for field_validation: https://main-jenkins-csb-migrationqe.apps.ocp-c1.prod.psi.redhat.com/view/MTA/job/mta/job/mta-ui-tests-runner/770/
jenkins run for crud test: https://main-jenkins-csb-migrationqe.apps.ocp-c1.prod.psi.redhat.com/view/MTA/job/mta/job/mta-ui-tests-runner/771/
<!-- Add pull request description here -->

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
