### PR TITLE
[RFR] Add Cypress tuning options: experimentalMemoryManagement, numTestsKep…

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -49,5 +49,7 @@ export default defineConfig({
             require("./cypress/plugins/index.js")(on, config);
             on("file:preprocessor", tagify(config));
         },
+        experimentalMemoryManagement: true,
+        numTestsKeptInMemory: 15,
     },
 });


### PR DESCRIPTION
Add the following Cypress tuning options in cypress.config.ts -
1)experimentalMemoryManagement, 
2) numTestsKeptInMemory

experimentalMemoryManagement - This is an experimental feature for improved memory management within Chromium-based browsers. Experimental features might change or ultimately be removed without making it into the core product. 
If this option doesn't make it to the core product, we'll have to remove this option from the cypress.config.ts file.

numTestsKeptInMemory - The number of tests for which snapshots and command data are kept in memory. Reduce this number if you are experiencing high memory consumption in your browser during a test run.  The default value is 50.

<!-- Add pull request description here -->

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
