### PR TITLE
[RFR] changed clicking with focus to clicking using JS when creating migration wave

### DIFF
--- a/cypress/e2e/models/migration/migration-waves/migration-wave.ts
+++ b/cypress/e2e/models/migration/migration-waves/migration-wave.ts
@@ -2,7 +2,7 @@ import {
     callWithin,
     click,
     clickByText,
-    clickWithFocus,
+    clickJs,
     inputText,
     selectItemsPerPage,
     selectUserPerspective,
@@ -83,7 +83,7 @@ export class MigrationWave {
     public create() {
         MigrationWave.openNewForm();
         this.fillForm(this);
-        clickWithFocus(MigrationWaveView.submitButton);
+        clickJs(MigrationWaveView.submitButton);
         this.setApplications();
     }
 


### PR DESCRIPTION
<!-- Add pull request description here -->
clicking with focus stop working on creating a migration wave
also clicking using cypress
changed to clicking with JS
jenkins run : https://main-jenkins-csb-migrationqe.apps.ocp-c1.prod.psi.redhat.com/view/MTA/job/mta/job/tackle-ui-tests-on-ocp/514/console
![image](https://github.com/konveyor/tackle-ui-tests/assets/132557033/778e602a-ff35-45b5-9068-039f2b281a77)

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
