### PR TITLE
[RFR] [CR] Refactor deleteApplicationTableRows()

### DIFF
--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -833,30 +833,15 @@ export function deleteApplicationTableRows(): void {
     // are imported. For all other tests use deleteByList(appList)
     navigate_to_application_inventory();
     cy.get(commonView.appTable)
-        .next()
-        .then(($div) => {
-            if (!$div.hasClass("pf-c-empty-state")) {
-                cy.get("tbody")
-                    .find(trTag)
-                    .not(".pf-c-table__expandable-row")
-                    .each(($tableRow) => {
-                        const name = $tableRow.find("td[data-label=Name]").text();
-                        cy.get(tdTag)
-                            .contains(name)
-                            .closest(trTag)
-                            .within(() => {
-                                click(actionButton);
-                            })
-                            .contains(button, deleteAction)
-                            .then(($delete_btn) => {
-                                if (!$delete_btn.hasClass("pf-m-aria-disabled")) {
-                                    $delete_btn.click();
-                                    cy.wait(800);
-                                    click(commonView.confirmButton);
-                                    cy.wait(2000);
-                                }
-                            });
-                    });
+        .find(trTag)
+        .each(($tableRow) => {
+            if ($tableRow.hasClass("pf-m-clickable")) {
+                cy.wrap($tableRow).within(() => {
+                    cy.get(sideKebabMenuImports, { timeout: 10000 }).click();
+                    cy.get("ul[role=menu] > li").contains("Delete").click();
+                });
+                cy.get(commonView.confirmButton).click();
+                cy.wait(4000);
             }
         });
 }


### PR DESCRIPTION
<!-- Add pull request description here -->
1)I've updated deleteApplicationTableRows()  since the DOM tree structure on the upstream Application Inventory page has been updated . 
2) The new deleteApplicationTableRows() works only on the Application Inventory -> Assessment page since this has been adapted for PF5.   The  Application Inventory -> Analysis page will be adapted for PF5 after feature freeze. 
3) The deleteApplicationTableRows() fn works fine on an empty table and a non-empty table. 

Notes:
I will update PR with the results from Jenkins run shortly. The PR passed locally. 

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
