### PR TITLE
[RFR] Fixed tagcaterory/crud

### DIFF
--- a/cypress/e2e/tests/migration/controls/tags/tagcategory/crud.test.ts
+++ b/cypress/e2e/tests/migration/controls/tags/tagcategory/crud.test.ts
@@ -50,7 +50,7 @@ describe(["@tier1"], "Tag tagCategory CRUD operations", () => {
         exists(updatedTagType);
 
         // Assert that rank got updated
-        tagCategory.assertColumnValue(rank, updatedRank);
+        tagCategory.assertColumnValue(rank, updatedRank.toString());
 
         // Assert that color got updated
         tagCategory.assertColumnValue(color, updatedColor);


### PR DESCRIPTION
<!-- Add pull request description here -->
The problem was that method `assertColumnValue` expects string, while variable `updatedRank` is a number. Now variable is converted to string before passing it to method and this resolves the problem.
<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
