### PR TITLE
[RFR] [JF] Improve bulk deletion test

### DIFF
--- a/cypress/e2e/tests/migration/applicationinventory/applications/bulk_deletion_applications.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/applications/bulk_deletion_applications.test.ts
@@ -25,11 +25,20 @@ import {
 
 import { Assessment } from "../../../../models/migration/applicationinventory/assessment";
 import * as commonView from "../../../../views/common.view";
-import { bulkApplicationSelectionCheckBox } from "../../../../views/applicationinventory.view";
+import {
+    actionButton,
+    bulkApplicationSelectionCheckBox,
+} from "../../../../views/applicationinventory.view";
 
 describe(["@tier2"], "Bulk deletion of applications", () => {
     before("Login", function () {
         login();
+        Assessment.open(100, true);
+        cy.get("tr.pf-m-clickable").then(($rows) => {
+            if ($rows.length > 0) {
+                verifyDeleteButton();
+            }
+        });
     });
 
     beforeEach("Interceptors", function () {
@@ -62,4 +71,20 @@ describe(["@tier2"], "Bulk deletion of applications", () => {
         application_inventory_kebab_menu("Delete");
         click(commonView.confirmButton);
     });
+
+    const verifyDeleteButton = () => {
+        cy.get("button.pf-v5-c-menu-toggle__button").click();
+        cy.get("ul[role=menu] > li").contains("Select all").click();
+        cy.get(actionButton).eq(0).click({ force: true });
+        cy.get("li.pf-v5-c-menu__list-item")
+            .contains("Delete")
+            .then(($deleteButton) => {
+                if ($deleteButton.parent().hasClass("pf-m-aria-disabled")) {
+                    expect(
+                        true,
+                        "The Bulk Delete button is disabled, which may be caused by undeleted migration waves from previous tests."
+                    ).to.eq(false);
+                }
+            });
+    };
 });


### PR DESCRIPTION
<!-- Add pull request description here -->
Solves [MTA-1548](https://issues.redhat.com/browse/MTA-1548)

This test was failing because the delete button was disabled due to migration waves with associated applications that were not deleted from previous tests.

Since migration waves can remain undeleted due to failures in other tests or bugs in the product, it is not the responsibility of this test to delete those migration waves.

That's why this PR adds a check so that the test won't run if there is remaining data and indicates that it has failed for that reason. It suggests checking the existence of undeleted data as the first likely cause.

Jenkins run [1092](https://main-jenkins-csb-migrationqe.apps.ocp-c1.prod.psi.redhat.com/view/MTA/job/mta/job/mta-ui-tests-runner/1092/console)

![image](https://github.com/konveyor/tackle-ui-tests/assets/117646518/87e90a07-9a0a-4c4d-bbbe-88907658a38a)

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
