### PR TITLE
[RFR] Add separate tests for discarding Assessment and Review

### DIFF
--- a/cypress/e2e/models/migration/applicationinventory/assessment.ts
+++ b/cypress/e2e/models/migration/applicationinventory/assessment.ts
@@ -394,11 +394,11 @@ export class Assessment extends Application {
         }
     }
 
-    discard_assessment(): void {
+    selectKebabMenuItem(selection: string): void {
         Application.open();
         selectItemsPerPage(100);
         this.selectApplication();
-        clickItemInKebabMenu(this.name, "Discard assessment/review");
+        clickItemInKebabMenu(this.name, selection);
         cy.get(continueButton).click();
     }
 

--- a/cypress/e2e/tests/migration/applicationinventory/assessment/miscellaneous.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/assessment/miscellaneous.test.ts
@@ -55,11 +55,23 @@ describe(["@tier3"], "Tests related to application assessment and review", () =>
         applicationList[0].verifyStatus("review", "Completed");
     });
 
-    it("Discard Assess/Review", function () {
-        applicationList[0].discard_assessment();
-        /* Add this after bug MTA-1611 is resolved.
-        checkSuccessAlert(alertTitle, `Success alert:Success! Assessment discarded for applicationList[0].name.`);
-        applicationList[0].verifyStatus("assessment", "Not started"); */
+    it("Discard Assess", function () {
+        applicationList[0].selectKebabMenuItem("Discard assessment(s)");
+        /* Add this after bug MTA-1611 is resolved. */
+        checkSuccessAlert(
+            alertTitle,
+            `Success alert:Success! Assessment discarded for applicationList[0].name.`
+        );
+        applicationList[0].verifyStatus("assessment", "Not started");
+        checkSuccessAlert(
+            alertTitle,
+            `Success alert:Success! Review discarded for ${applicationList[0].name}.`
+        );
+        applicationList[0].verifyStatus("assessment", "Not started");
+    });
+
+    it("Discard Review", function () {
+        applicationList[0].selectKebabMenuItem("Discard review");
         checkSuccessAlert(
             alertTitle,
             `Success alert:Success! Review discarded for ${applicationList[0].name}.`

--- a/cypress/e2e/tests/migration/applicationinventory/assessment/miscellaneous.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/assessment/miscellaneous.test.ts
@@ -55,17 +55,11 @@ describe(["@tier3"], "Tests related to application assessment and review", () =>
         applicationList[0].verifyStatus("review", "Completed");
     });
 
-    it("Discard Assess", function () {
+    it("Discard Assessment", function () {
         applicationList[0].selectKebabMenuItem("Discard assessment(s)");
-        /* Add this after bug MTA-1611 is resolved. */
         checkSuccessAlert(
             alertTitle,
             `Success alert:Success! Assessment discarded for applicationList[0].name.`
-        );
-        applicationList[0].verifyStatus("assessment", "Not started");
-        checkSuccessAlert(
-            alertTitle,
-            `Success alert:Success! Review discarded for ${applicationList[0].name}.`
         );
         applicationList[0].verifyStatus("assessment", "Not started");
     });

--- a/cypress/e2e/tests/migration/applicationinventory/assessment/miscellaneous.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/assessment/miscellaneous.test.ts
@@ -59,7 +59,7 @@ describe(["@tier3"], "Tests related to application assessment and review", () =>
         applicationList[0].selectKebabMenuItem("Discard assessment(s)");
         checkSuccessAlert(
             alertTitle,
-            `Success alert:Success! Assessment discarded for applicationList[0].name.`
+            `Success alert:Success! Assessment discarded for ${applicationList[0].name}.`
         );
         applicationList[0].verifyStatus("assessment", "Not started");
     });


### PR DESCRIPTION
<!-- Add pull request description here -->
The 'Discard assessment/Review' option is now split into 'Discard assessment' and 'Discard review' . So, I'm submitting this PR to address the changes . 

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
