### PR TITLE
[RFR] Verify field(s) are populated on application drawer after review inheritance from multiple archetypes

### DIFF
--- a/cypress/e2e/models/migration/applicationinventory/application.ts
+++ b/cypress/e2e/models/migration/applicationinventory/application.ts
@@ -79,6 +79,7 @@ import {
     validateTextPresence,
     validateNumberPresence,
     performWithin,
+    sidedrawerTab,
 } from "../../../../utils/utils";
 import { AppIssue, applicationData, RbacValidationRules } from "../../../types/types";
 import { rightSideMenu, sourceDropdown } from "../../../views/analysis.view";
@@ -640,11 +641,20 @@ export class Application {
         Assessment.validateReviewFields(this.name, "Application");
     }
 
-    validateInheritedReviewFields(archetypes): void {
+    verifyArchetypeReviewedList(archetypeList): void {
         Application.open();
-        for (let i in archetypes) {
-            Assessment.validateReviewFields(this.name, "Archetype", archetypes[i].name);
-        }
+        sidedrawerTab(this.name, "Details");
+        cy.get(commonView.sideDrawer.associatedArchetypes).contains("Archetypes reviewed");
+        cy.get("dt")
+            .contains("Archetypes reviewed")
+            .closest("div")
+            .within(() => {
+                cy.get("dd").then(($value) => {
+                    const text = $value.text();
+                    expect(text).to.equal(archetypeList[0].name + archetypeList[1].name);
+                });
+            });
+        click(commonView.sideDrawer.closeDrawer);
     }
 
     retake_questionnaire(

--- a/cypress/e2e/models/migration/applicationinventory/application.ts
+++ b/cypress/e2e/models/migration/applicationinventory/application.ts
@@ -640,6 +640,13 @@ export class Application {
         Assessment.validateReviewFields(this.name, "Application");
     }
 
+    validateInheritedReviewFields(archetypes): void {
+        Application.open();
+        for (let i in archetypes) {
+            Assessment.validateReviewFields(this.name, "Archetype", archetypes[i].name);
+        }
+    }
+
     retake_questionnaire(
         risk,
         stakeholders?: Stakeholders[],

--- a/cypress/e2e/models/migration/applicationinventory/assessment.ts
+++ b/cypress/e2e/models/migration/applicationinventory/assessment.ts
@@ -43,7 +43,6 @@ import {
 import { Stakeholdergroups } from "../controls/stakeholdergroups";
 import { Stakeholders } from "../controls/stakeholders";
 import { notYetReviewed, reviewItems } from "../../../views/archetype.view";
-import { Archetype } from "../archetypes/archetype";
 
 export class Assessment {
     public static selectStakeholders(stakeholders: Stakeholders[]): void {

--- a/cypress/e2e/models/migration/applicationinventory/assessment.ts
+++ b/cypress/e2e/models/migration/applicationinventory/assessment.ts
@@ -43,6 +43,7 @@ import {
 import { Stakeholdergroups } from "../controls/stakeholdergroups";
 import { Stakeholders } from "../controls/stakeholders";
 import { notYetReviewed, reviewItems } from "../../../views/archetype.view";
+import { Archetype } from "../archetypes/archetype";
 
 export class Assessment {
     public static selectStakeholders(stakeholders: Stakeholders[]): void {
@@ -216,7 +217,8 @@ export class Assessment {
         cy.wait(2 * SEC);
     }
 
-    public static validateReviewFields(name: string, entityName: string): void {
+    public static validateReviewFields(name: string, entityName: string, archetype?: string): void {
+        if (archetype) name = archetype;
         let list = [
             "Proposed action",
             "Effort estimate",

--- a/cypress/e2e/models/migration/applicationinventory/assessment.ts
+++ b/cypress/e2e/models/migration/applicationinventory/assessment.ts
@@ -217,8 +217,7 @@ export class Assessment {
         cy.wait(2 * SEC);
     }
 
-    public static validateReviewFields(name: string, entityName: string, archetype?: string): void {
-        if (archetype) name = archetype;
+    public static validateReviewFields(name: string, entityName: string): void {
         let list = [
             "Proposed action",
             "Effort estimate",

--- a/cypress/e2e/tests/migration/applicationinventory/assessment/archetype_association.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/assessment/archetype_association.test.ts
@@ -21,6 +21,7 @@ import {
     click,
     login,
     createMultipleTags,
+    createMultipleArchetypes,
     deleteByList,
     sidedrawerTab,
 } from "../../../../../utils/utils";
@@ -30,7 +31,7 @@ import { SEC } from "../../../../types/constants";
 import { Tag } from "../../../../models/migration/controls/tags";
 
 let applicationList: Array<Application> = [];
-let archetypeList: Array<Archetype> = [];
+let archetypes: Array<Archetype> = [];
 let tags: Tag[];
 
 describe(["@tier2"], "Tests related to application-archetype association ", () => {
@@ -69,6 +70,34 @@ describe(["@tier2"], "Tests related to application-archetype association ", () =
         sidedrawerTab(application.name, "Details");
         cy.get(commonView.sideDrawer.associatedArchetypes).contains("Associated archetypes");
         cy.get(commonView.sideDrawer.labelContent).contains(archetype.name);
+        click(commonView.sideDrawer.closeDrawer);
+    });
+
+    it("Verify application review from multiple archetypes", function () {
+        // Automates MTA-420
+        const appdata = {
+            name: data.getAppName(),
+            description: data.getDescription(),
+            tags: [tags[0].name],
+            comment: data.getDescription(),
+        };
+
+        const application = new Application(appdata);
+        applicationList.push(application);
+        application.create();
+        cy.wait(2 * SEC);
+
+        archetypes = createMultipleArchetypes(2);
+
+        // Assert that 'Archetypes reviewed' is populated on app drawer after review inheritance
+        Application.open();
+        sidedrawerTab(application.name, "Details");
+        cy.get(commonView.sideDrawer.associatedArchetypes).contains("Associated archetypes");
+        cy.get(commonView.sideDrawer.labelContent).contains(archetype.name);
+        cy.get(commonView.sideDrawer.associatedArchetypes).contains("Archetypes reviewed");
+
+        // Assert that inherited review details are listed on the 'Reviews' tab
+        sidedrawerTab(application.name, "Details");
         click(commonView.sideDrawer.closeDrawer);
     });
 

--- a/cypress/e2e/tests/migration/applicationinventory/assessment/archetype_association.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/assessment/archetype_association.test.ts
@@ -73,7 +73,7 @@ describe(["@tier2"], "Tests related to application-archetype association ", () =
         click(commonView.sideDrawer.closeDrawer);
     });
 
-    it.only("Verify application review inherotance from multiple archetypes ", function () {
+    it("Verify application review inheritance from multiple archetypes ", function () {
         /* Automates MTA-420
         This also verifies: Archetype association - Application creation after archetype creation.
         */

--- a/cypress/e2e/tests/migration/applicationinventory/assessment/archetype_association.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/assessment/archetype_association.test.ts
@@ -73,9 +73,8 @@ describe(["@tier2"], "Tests related to application-archetype association ", () =
         click(commonView.sideDrawer.closeDrawer);
     });
 
-    it.only("Verify application review from multiple archetypes", function () {
+    it("Verify application review from multiple archetypes", function () {
         // Automates MTA-420
-
         archetypes = createMultipleArchetypes(2, tags);
 
         const appdata = {
@@ -90,16 +89,25 @@ describe(["@tier2"], "Tests related to application-archetype association ", () =
         application.create();
         cy.wait(2 * SEC);
 
+        archetypes[0].perform_review("low");
+        archetypes[1].perform_review("medium");
+
         // Assert that 'Archetypes reviewed' is populated on app drawer after review inheritance
         Application.open();
         sidedrawerTab(application.name, "Details");
-        cy.get(commonView.sideDrawer.associatedArchetypes).contains("Associated archetypes");
-        cy.get(commonView.sideDrawer.labelContent).contains(archetypes[0].name, archetypes[1].name);
         cy.get(commonView.sideDrawer.associatedArchetypes).contains("Archetypes reviewed");
+        cy.get("dt")
+            .contains("Archetypes reviewed")
+            .closest("div")
+            .within(() => {
+                cy.get("dd").then(($value) => {
+                    let text = $value.text();
+                    expect(text).to.equal(archetypes[0].name + archetypes[1].name);
+                });
+            });
 
         // Assert that inherited review details are listed on the 'Reviews' tab
-        sidedrawerTab(application.name, "Details");
-        click(commonView.sideDrawer.closeDrawer);
+        application.validateInheritedReviewFields(archetypes);
     });
 
     after("Perform test data clean up", function () {

--- a/cypress/e2e/tests/migration/applicationinventory/assessment/archetype_association.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/assessment/archetype_association.test.ts
@@ -73,8 +73,10 @@ describe(["@tier2"], "Tests related to application-archetype association ", () =
         click(commonView.sideDrawer.closeDrawer);
     });
 
-    it("Verify application review from multiple archetypes", function () {
-        // Automates MTA-420
+    it.only("Verify application review inherotance from multiple archetypes ", function () {
+        /* Automates MTA-420
+        This also verifies: Archetype association - Application creation after archetype creation.
+        */
         archetypeList = createMultipleArchetypes(2, tags);
 
         const appdata = {
@@ -93,21 +95,7 @@ describe(["@tier2"], "Tests related to application-archetype association ", () =
         archetypeList[1].perform_review("medium");
 
         // Assert that 'Archetypes reviewed' is populated on app drawer after review inheritance
-        Application.open();
-        sidedrawerTab(application.name, "Details");
-        cy.get(commonView.sideDrawer.associatedArchetypes).contains("Archetypes reviewed");
-        cy.get("dt")
-            .contains("Archetypes reviewed")
-            .closest("div")
-            .within(() => {
-                cy.get("dd").then(($value) => {
-                    let text = $value.text();
-                    expect(text).to.equal(archetypeList[0].name + archetypeList[1].name);
-                });
-            });
-
-        // Assert that inherited review inheritance details are listed on the 'Reviews' tab
-        application.validateInheritedReviewFields(archetypeList);
+        application.verifyArchetypeReviewedList(archetypeList);
     });
 
     after("Perform test data clean up", function () {

--- a/cypress/e2e/tests/migration/applicationinventory/assessment/archetype_association.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/assessment/archetype_association.test.ts
@@ -31,7 +31,7 @@ import { SEC } from "../../../../types/constants";
 import { Tag } from "../../../../models/migration/controls/tags";
 
 let applicationList: Array<Application> = [];
-let archetypes: Array<Archetype> = [];
+let archetypeList: Array<Archetype> = [];
 let tags: Tag[];
 
 describe(["@tier2"], "Tests related to application-archetype association ", () => {
@@ -75,7 +75,7 @@ describe(["@tier2"], "Tests related to application-archetype association ", () =
 
     it("Verify application review from multiple archetypes", function () {
         // Automates MTA-420
-        archetypes = createMultipleArchetypes(2, tags);
+        archetypeList = createMultipleArchetypes(2, tags);
 
         const appdata = {
             name: data.getAppName(),
@@ -89,8 +89,8 @@ describe(["@tier2"], "Tests related to application-archetype association ", () =
         application.create();
         cy.wait(2 * SEC);
 
-        archetypes[0].perform_review("low");
-        archetypes[1].perform_review("medium");
+        archetypeList[0].perform_review("low");
+        archetypeList[1].perform_review("medium");
 
         // Assert that 'Archetypes reviewed' is populated on app drawer after review inheritance
         Application.open();
@@ -102,17 +102,17 @@ describe(["@tier2"], "Tests related to application-archetype association ", () =
             .within(() => {
                 cy.get("dd").then(($value) => {
                     let text = $value.text();
-                    expect(text).to.equal(archetypes[0].name + archetypes[1].name);
+                    expect(text).to.equal(archetypeList[0].name + archetypeList[1].name);
                 });
             });
 
-        // Assert that inherited review details are listed on the 'Reviews' tab
-        application.validateInheritedReviewFields(archetypes);
+        // Assert that inherited review inheritance details are listed on the 'Reviews' tab
+        application.validateInheritedReviewFields(archetypeList);
     });
 
     after("Perform test data clean up", function () {
         deleteByList(applicationList);
-        deleteByList(archetypes);
+        deleteByList(archetypeList);
         deleteByList(tags);
     });
 });

--- a/cypress/e2e/tests/migration/applicationinventory/assessment/archetype_association.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/assessment/archetype_association.test.ts
@@ -73,12 +73,15 @@ describe(["@tier2"], "Tests related to application-archetype association ", () =
         click(commonView.sideDrawer.closeDrawer);
     });
 
-    it("Verify application review from multiple archetypes", function () {
+    it.only("Verify application review from multiple archetypes", function () {
         // Automates MTA-420
+
+        archetypes = createMultipleArchetypes(2, tags);
+
         const appdata = {
             name: data.getAppName(),
             description: data.getDescription(),
-            tags: [tags[0].name],
+            tags: [tags[0].name, tags[1].name],
             comment: data.getDescription(),
         };
 
@@ -87,13 +90,11 @@ describe(["@tier2"], "Tests related to application-archetype association ", () =
         application.create();
         cy.wait(2 * SEC);
 
-        archetypes = createMultipleArchetypes(2);
-
         // Assert that 'Archetypes reviewed' is populated on app drawer after review inheritance
         Application.open();
         sidedrawerTab(application.name, "Details");
         cy.get(commonView.sideDrawer.associatedArchetypes).contains("Associated archetypes");
-        cy.get(commonView.sideDrawer.labelContent).contains(archetype.name);
+        cy.get(commonView.sideDrawer.labelContent).contains(archetypes[0].name, archetypes[1].name);
         cy.get(commonView.sideDrawer.associatedArchetypes).contains("Archetypes reviewed");
 
         // Assert that inherited review details are listed on the 'Reviews' tab
@@ -103,7 +104,7 @@ describe(["@tier2"], "Tests related to application-archetype association ", () =
 
     after("Perform test data clean up", function () {
         deleteByList(applicationList);
-        deleteByList(archetypeList);
+        deleteByList(archetypes);
         deleteByList(tags);
     });
 });

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -947,7 +947,7 @@ export function createMultipleArchetypes(number, tags?: Tag[]): Archetype[] {
     for (let i = 0; i < number; i++) {
         let archetype: Archetype;
         if (tags) archetype = new Archetype(data.getRandomWord(6), [tags[i].name], [tags[i].name]);
-        else archetype = new Archetype(randomTagName, [tags[i].name], [tags[i].name]);
+        else archetype = new Archetype(data.getRandomWord(6), [randomTagName], [randomTagName]);
         archetype.create();
         cy.wait(2 * SEC);
         archetypesList.push(archetype);

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -941,11 +941,13 @@ export function createMultipleJobFunctions(num): Array<Jobfunctions> {
     return jobFunctionsList;
 }
 
-export function createMultipleArchetypes(number, tags: Tag[]): Archetype[] {
-    // const randomTagName = "3rd party / Apache Aries";
+export function createMultipleArchetypes(number, tags?: Tag[]): Archetype[] {
+    const randomTagName = "3rd party / Apache Aries";
     let archetypesList: Archetype[] = [];
     for (let i = 0; i < number; i++) {
-        const archetype = new Archetype(data.getRandomWord(6), [tags[i].name], [tags[i].name]);
+        let archetype: Archetype;
+        if (tags) archetype = new Archetype(data.getRandomWord(6), [tags[i].name], [tags[i].name]);
+        else archetype = new Archetype(randomTagName, [tags[i].name], [tags[i].name]);
         archetype.create();
         cy.wait(2 * SEC);
         archetypesList.push(archetype);

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -941,10 +941,9 @@ export function createMultipleJobFunctions(num): Array<Jobfunctions> {
     return jobFunctionsList;
 }
 
-export function createMultipleArchetypes(number): Archetype[] {
-    const randomTagName = "3rd party / Apache Aries";
+export function createMultipleArchetypes(number, tags: Tag[]): Archetype[] {
+    // const randomTagName = "3rd party / Apache Aries";
     let archetypesList: Archetype[] = [];
-    let tags = createMultipleTags(number);
     for (let i = 0; i < number; i++) {
         const archetype = new Archetype(data.getRandomWord(6), [tags[i].name], [tags[i].name]);
         archetype.create();

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -944,8 +944,9 @@ export function createMultipleJobFunctions(num): Array<Jobfunctions> {
 export function createMultipleArchetypes(number): Archetype[] {
     const randomTagName = "3rd party / Apache Aries";
     let archetypesList: Archetype[] = [];
+    let tags = createMultipleTags(number);
     for (let i = 0; i < number; i++) {
-        const archetype = new Archetype(data.getRandomWord(6), [randomTagName], [randomTagName]);
+        const archetype = new Archetype(data.getRandomWord(6), [tags[i].name], [tags[i].name]);
         archetype.create();
         cy.wait(2 * SEC);
         archetypesList.push(archetype);


### PR DESCRIPTION
<!-- Add pull request description here -->

Notes:
1)   I'm validating that 'Archetypes reviewed' is populated with the correct values through this PR.  I will add validateInheritedReviewFields() through another PR . It needs additional testing since the base method is used by both archetypes and applications.
2) [Jenkins job](https://main-jenkins-csb-migrationqe.apps.ocp-c1.prod.psi.redhat.com/job/mta/job/mta-ui-tests-runner/1698)
<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
