### PR TITLE
[RFR] Bring back svn tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -10,6 +10,8 @@ export default defineConfig({
         pass: "Dog8code",
         git_user: "",
         git_password: "",
+        svn_user: "qe-admin",
+        svn_password: "Dog8code",
         jira_stage_datacenter_url: "https://issues.stage.redhat.com/",
         jira_stage_bearer_token: "",
         jira_stage_basic_login: "",

--- a/cypress/e2e/tests/administration/repository/subversion.test.ts
+++ b/cypress/e2e/tests/administration/repository/subversion.test.ts
@@ -21,31 +21,35 @@ import {
     getRandomAnalysisData,
     getRandomApplicationData,
     login,
-    resetURL,
-    writeMavenSettingsFile,
 } from "../../../../utils/utils";
-import * as data from "../../../../utils/data_utils";
 import { SubversionConfiguration } from "../../../models/administration/repositories/subversion";
 import { CredentialsSourceControlUsername } from "../../../models/administration/credentials/credentialsSourceControlUsername";
-import { button, CredentialType, SEC, UserCredentials } from "../../../types/constants";
+import {
+    AnalysisStatuses,
+    button,
+    CredentialType,
+    SEC,
+    UserCredentials,
+} from "../../../types/constants";
 import { Analysis } from "../../../models/migration/applicationinventory/analysis";
 import { footer } from "../../../views/common.view";
-
-let subversionConfiguration = new SubversionConfiguration();
-let source_credential: CredentialsSourceControlUsername;
-let applicationsList: Analysis[] = [];
+import { getDescription, getRandomWord } from "../../../../utils/data_utils";
 
 describe(["@tier1"], "Test secure and insecure svn repository analysis", () => {
+    const subversionConfiguration = new SubversionConfiguration();
+    let sourceCredential: CredentialsSourceControlUsername;
+    let applicationsList: Analysis[] = [];
+
     before("Login", function () {
         login();
-        source_credential = new CredentialsSourceControlUsername(
-            data.getRandomCredentialsData(
-                CredentialType.sourceControl,
-                UserCredentials.usernamePassword,
-                true
-            )
-        );
-        source_credential.create();
+        sourceCredential = new CredentialsSourceControlUsername({
+            type: CredentialType.sourceControl,
+            name: getRandomWord(6),
+            description: getDescription(),
+            username: Cypress.env("svn_user"),
+            password: Cypress.env("svn_password"),
+        });
+        sourceCredential.create();
     });
 
     beforeEach("Load data", function () {
@@ -56,61 +60,51 @@ describe(["@tier1"], "Test secure and insecure svn repository analysis", () => {
             this.analysisData = analysisData;
         });
 
-        // Interceptors
-        cy.intercept("POST", "/hub/application*").as("postApplication");
         cy.intercept("GET", "/hub/application*").as("getApplication");
     });
 
-    // test that when the insecure repository is enabled, then the analysis on a http repo should be completed successfully
-    // Skipped until a svn server is provided in https://issues.redhat.com/browse/MTA-1717
-    it.skip("Analysis on insecure subversion Repository(http) for tackle test app when insecure repository is allowed", function () {
+    it("Analysis on insecure SVN Repository(http) when allowed", function () {
         subversionConfiguration.enableInsecureSubversionRepositories();
 
         const application = new Analysis(
-            getRandomApplicationData("Secure_enabled_tackle_test_app", {
-                sourceData: this.appData["tackle-testapp-svn-insecure"],
+            getRandomApplicationData("Insecure svn enabled bookserver app", {
+                sourceData: this.appData["bookserver-svn-insecure"],
             }),
             getRandomAnalysisData(this.analysisData["source_analysis_on_bookserverapp"])
         );
         application.create();
         applicationsList.push(application);
         cy.wait("@getApplication");
-        cy.wait(2 * SEC);
-        application.manageCredentials(source_credential.name, null);
+        application.manageCredentials(sourceCredential.name, null);
         application.analyze();
-        application.verifyAnalysisStatus("Completed");
-        application.openReport();
+        application.verifyAnalysisStatus(AnalysisStatuses.completed);
     });
 
-    // Negative test case, when the insecure repository is disabled, then the analysis on a http repo should fail
-    it("Analysis on insecure subversion Repository(http) for tackle test app when insecure repository is not allowed", function () {
+    it("Analysis on insecure SVN Repository(http) when not allowed", function () {
         subversionConfiguration.disableInsecureSubversionRepositories();
 
         const application = new Analysis(
-            getRandomApplicationData("Secure_disabled_tackle_test_app", {
-                sourceData: this.appData["tackle-testapp-svn-insecure"],
+            getRandomApplicationData("Insecure svn disabled bookserver app", {
+                sourceData: this.appData["bookserver-svn-insecure"],
             }),
             getRandomAnalysisData(this.analysisData["source_analysis_on_bookserverapp"])
         );
         application.create();
         applicationsList.push(application);
         cy.wait("@getApplication");
-        cy.wait(2 * SEC);
-        application.manageCredentials(source_credential.name, null);
+        application.manageCredentials(sourceCredential.name, null);
         application.analyze();
-        application.verifyAnalysisStatus("Failed");
+        application.verifyAnalysisStatus(AnalysisStatuses.failed);
         application.openAnalysisDetails();
         clickWithinByText(footer, button, "Close");
     });
 
-    afterEach("Persist session", function () {
-        // Reset URL from report page to web UI
-        resetURL();
+    afterEach("Clear state", function () {
+        Analysis.open(true);
     });
 
     after("Perform test data clean up", () => {
         deleteByList(applicationsList);
-        source_credential.delete();
-        writeMavenSettingsFile(data.getRandomWord(5), data.getRandomWord(5));
+        sourceCredential.delete();
     });
 });

--- a/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
@@ -167,24 +167,6 @@ describe(["@tier1"], "Source Analysis", () => {
         application.verifyAnalysisStatus("Completed");
     });
 
-    // Skipped until a svn server is provided in https://issues.redhat.com/browse/MTA-1717
-    it.skip("Source Analysis on tackle testapp for svn repo type", function () {
-        // For tackle test app source credentials are required.
-        const application = new Analysis(
-            getRandomApplicationData("tackleTestApp_svnRepo", {
-                sourceData: this.appData["tackle-testapp-svn"],
-            }),
-            getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        cy.wait(2 * SEC);
-        application.manageCredentials(source_credential.name, null);
-        application.analyze();
-        application.verifyAnalysisStatus("Completed");
-    });
-
     it("Analysis for known Open Source libraries on tackleTest app", function () {
         // Source code analysis require both source and maven credentials
         const application = new Analysis(

--- a/cypress/fixtures/application.json
+++ b/cypress/fixtures/application.json
@@ -29,9 +29,9 @@
         "repoType": "Git",
         "sourceRepo": "http://github.com/konveyor/tackle-testapp"
     },
-    "tackle-testapp-svn-insecure": {
+    "bookserver-svn-insecure": {
         "repoType": "Subversion",
-        "sourceRepo": "http://github.com/konveyor/tackle-testapp"
+        "sourceRepo": "http://10.0.188.129/svn/mtaqe-svn/book-server"
     },
     "konveyor-exampleapp": {
         "repoType": "Git",


### PR DESCRIPTION
<!-- Add pull request description here -->

Solves [MTA-1744](https://issues.redhat.com/browse/MTA-1744) by Automating [MTA-1717](https://issues.redhat.com/browse/MTA-1717)

On January 8, 2024,[ GitHub removed support for Subversion](https://github.blog/2023-01-20-sunsetting-subversion-support/), making it unnecessary to maintain the test that was in the source_analysis suite, as it would be practically identical to the one in subversion.test.ts.

I have brought back the Subversion test, making the necessary adaptations, and removed the one from source_analysis since it's a duplicate, and both tests run on the same tier.

---

Jenkins run [1891](https://main-jenkins-csb-migrationqe.apps.ocp-c1.prod.psi.redhat.com/view/MTA/job/mta/job/mta-ui-tests-runner/1891/console)

![image](https://github.com/konveyor/tackle-ui-tests/assets/117646518/18bcb67d-9025-48be-b785-4e1117208084)

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
