### PR TITLE
[RFR] automate auto tagging of archetypes based on answers and use questionnaire template in test

### DIFF
--- a/cypress/e2e/models/migration/archetypes/archetype.ts
+++ b/cypress/e2e/models/migration/archetypes/archetype.ts
@@ -34,6 +34,7 @@ import { Stakeholders } from "../controls/stakeholders";
 import * as archetype from "../../../views/archetype.view";
 import * as commonView from "../../../views/common.view";
 import { Assessment } from "../applicationinventory/assessment";
+import { tagsColumnSelector } from "../../../views/applicationinventory.view";
 
 export interface Archetype {
     name: string;
@@ -342,6 +343,17 @@ export class Archetype {
                 this.clickAssessButton();
             }
             Assessment.verifyAssessmentTakeButtonEnabled();
+        });
+    }
+    validateTagsColumn(tagsNames: string[]): void {
+        Archetype.open();
+        tagsNames.forEach((tag) => {
+            cy.get(tdTag)
+                .contains(this.name)
+                .parent(trTag)
+                .within(() => {
+                    cy.get(tagsColumnSelector).contains(tag, { timeout: 30 * SEC });
+                });
         });
     }
 }

--- a/cypress/e2e/models/migration/archetypes/archetype.ts
+++ b/cypress/e2e/models/migration/archetypes/archetype.ts
@@ -345,6 +345,7 @@ export class Archetype {
             Assessment.verifyAssessmentTakeButtonEnabled();
         });
     }
+
     validateTagsColumn(tagsNames: string[]): void {
         Archetype.open();
         tagsNames.forEach((tag) => {

--- a/cypress/e2e/tests/migration/applicationinventory/assessment/miscellaneous.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/assessment/miscellaneous.test.ts
@@ -343,6 +343,7 @@ describe(["@tier3"], "Tests related to application assessment and review", () =>
         );
         archetype.create();
         archetype.perform_assessment("medium", stakeholderList, null, cloudReadinessQuestionnaire);
+        Archetype.open(true);
         archetype.validateTagsColumn(["Spring Boot"]);
         archetype.assertsTagsMatch("Assessment Tags", ["Spring Boot"], true, true);
         archetype.delete();

--- a/cypress/e2e/tests/migration/applicationinventory/assessment/miscellaneous.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/assessment/miscellaneous.test.ts
@@ -31,7 +31,14 @@ import {
 import { Stakeholders } from "../../../../models/migration/controls/stakeholders";
 import { AssessmentQuestionnaire } from "../../../../models/administration/assessment_questionnaire/assessment_questionnaire";
 import { alertTitle, confirmButton, successAlertMessage } from "../../../../views/common.view";
-import { legacyPathfinder, cloudNative, SEC, button } from "../../../../types/constants";
+import {
+    legacyPathfinder,
+    cloudNative,
+    SEC,
+    button,
+    cloudReadinessFilePath,
+    cloudReadinessQuestionnaire,
+} from "../../../../types/constants";
 import {
     ArchivedQuestionnaires,
     ArchivedQuestionnairesTableDataCell,
@@ -310,17 +317,25 @@ describe(["@tier3"], "Tests related to application assessment and review", () =>
 
     it("Validates auto tagging of applications based on assessment answers", function () {
         //automates polarion MTA-387
+        const appdata = { name: "test1", tags: ["Language / Java"] };
+        const application = new Application(appdata);
+        application.create();
         AssessmentQuestionnaire.deleteAllQuestionnaires();
-        AssessmentQuestionnaire.import(yamlFile);
-        AssessmentQuestionnaire.enable(cloudNative);
+        AssessmentQuestionnaire.import(cloudReadinessFilePath);
+        AssessmentQuestionnaire.enable(cloudReadinessQuestionnaire);
         AssessmentQuestionnaire.disable(legacyPathfinder);
 
-        const applications = createMultipleApplications(1);
-        applications[0].perform_assessment("medium", stakeholderList, null, cloudNative);
-        applications[0].validateTagsCount("1");
-        applications[0].applicationDetailsTab("Tags");
-        applications[0].tagAndCategoryExists("Spring Boot");
-        applications[0].closeApplicationDetails();
+        application.perform_assessment(
+            "medium",
+            stakeholderList,
+            null,
+            cloudReadinessQuestionnaire
+        );
+        application.validateTagsCount("2");
+        application.applicationDetailsTab("Tags");
+        application.tagAndCategoryExists("Spring Boot");
+        application.closeApplicationDetails();
+        application.delete();
     });
 
     after("Perform test data clean up", function () {

--- a/cypress/e2e/tests/migration/applicationinventory/assessment/miscellaneous.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/assessment/miscellaneous.test.ts
@@ -333,7 +333,7 @@ describe(["@tier3"], "Tests related to application assessment and review", () =>
         );
         application.validateTagsCount("2");
         application.applicationDetailsTab("Tags");
-        application.tagAndCategoryExists("Spring Boot");
+        application.tagAndCategoryExists([["Runtime", "Spring Boot"]]);
         application.closeApplicationDetails();
         const archetype = new Archetype(
             data.getRandomWord(8),
@@ -346,8 +346,15 @@ describe(["@tier3"], "Tests related to application assessment and review", () =>
         Archetype.open(true);
         archetype.validateTagsColumn(["Spring Boot"]);
         archetype.assertsTagsMatch("Assessment Tags", ["Spring Boot"], true, true);
+        const appdata2 = { name: "test2", tags: ["Language / Java"] };
+        const application2 = new Application(appdata2);
+        application2.create();
+        application2.applicationDetailsTab("Tags");
+        application2.tagAndCategoryExists([["Runtime", "Spring Boot"]]);
+
         archetype.delete();
         application.delete();
+        application2.delete();
     });
 
     after("Perform test data clean up", function () {

--- a/cypress/e2e/tests/migration/applicationinventory/assessment/miscellaneous.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/assessment/miscellaneous.test.ts
@@ -344,7 +344,7 @@ describe(["@tier3"], "Tests related to application assessment and review", () =>
         archetype.create();
         archetype.perform_assessment("medium", stakeholderList, null, cloudReadinessQuestionnaire);
         archetype.validateTagsColumn(["Spring Boot"]);
-        archetype.assertsTagsMatch("Assessment Tags", ["Spring Boot"], true, false);
+        archetype.assertsTagsMatch("Assessment Tags", ["Spring Boot"], true, true);
         archetype.delete();
         application.delete();
     });

--- a/cypress/e2e/tests/migration/applicationinventory/assessment/miscellaneous.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/assessment/miscellaneous.test.ts
@@ -316,7 +316,7 @@ describe(["@tier3"], "Tests related to application assessment and review", () =>
     });
 
     it("Validates auto tagging of applications based on assessment answers", function () {
-        //automates polarion MTA-387
+        //automates polarion MTA-387 and MTA-502
         const appdata = { name: "test1", tags: ["Language / Java"] };
         const application = new Application(appdata);
         application.create();
@@ -335,6 +335,17 @@ describe(["@tier3"], "Tests related to application assessment and review", () =>
         application.applicationDetailsTab("Tags");
         application.tagAndCategoryExists("Spring Boot");
         application.closeApplicationDetails();
+        const archetype = new Archetype(
+            data.getRandomWord(8),
+            ["Language / Java"],
+            ["Language / Java"],
+            null
+        );
+        archetype.create();
+        archetype.perform_assessment("medium", stakeholderList, null, cloudReadinessQuestionnaire);
+        archetype.validateTagsColumn(["Spring Boot"]);
+        archetype.assertsTagsMatch("Assessment Tags", ["Spring Boot"], true, false);
+        archetype.delete();
         application.delete();
     });
 

--- a/cypress/e2e/tests/migration/applicationinventory/assessment/miscellaneous.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/assessment/miscellaneous.test.ts
@@ -315,7 +315,7 @@ describe(["@tier3"], "Tests related to application assessment and review", () =>
         deleteByList(archetypes);
     });
 
-    it("Validates auto tagging of applications based on assessment answers", function () {
+    it("Validates auto tagging of applications and archetypes based on assessment answers", function () {
         //automates polarion MTA-387 and MTA-502
         const appdata = { name: "test1", tags: ["Language / Java"] };
         const application = new Application(appdata);
@@ -335,6 +335,7 @@ describe(["@tier3"], "Tests related to application assessment and review", () =>
         application.applicationDetailsTab("Tags");
         application.tagAndCategoryExists([["Runtime", "Spring Boot"]]);
         application.closeApplicationDetails();
+        // Automates Polarion MTA-502
         const archetype = new Archetype(
             data.getRandomWord(8),
             ["Language / Java"],


### PR DESCRIPTION
<!-- Add pull request description here -->
Polarion TC - [MTA502](https://polarion.engineering.redhat.com/polarion/#/project/MTAPathfinder/workitem?id=MTA-502) and [MTA-387](https://polarion.engineering.redhat.com/polarion/#/project/MTAPathfinder/workitem?id=MTA-387)
[jenkins](https://main-jenkins-csb-migrationqe.apps.ocp-c1.prod.psi.redhat.com/job/mta/job/mta-ui-tests-runner/2023/console)
Archetype.open(true); was added due to test failing to open archetype page.
<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
