### PR TITLE
Fix Interop Dockerfile

### DIFF
--- a/dockerfiles/interop/Dockerfile
+++ b/dockerfiles/interop/Dockerfile
@@ -5,10 +5,6 @@ FROM docker.io/cypress/included:12.11.0
 ENV CYPRESS_CACHE_FOLDER=/tmp/.cache/Cypress
 ENV npm_config_cache=/tmp/.cache/npm
 
-# Update container and install unzip
-#RUN apt -y update && \
-#    apt install -y unzip
-
 RUN mkdir /tmp/tackle-ui-tests
 WORKDIR /tmp/tackle-ui-tests
 COPY . .

--- a/dockerfiles/interop/Dockerfile
+++ b/dockerfiles/interop/Dockerfile
@@ -6,8 +6,8 @@ ENV CYPRESS_CACHE_FOLDER=/tmp/.cache/Cypress
 ENV npm_config_cache=/tmp/.cache/npm
 
 # Update container and install unzip
-RUN apt -y update && \
-    apt install -y unzip
+#RUN apt -y update && \
+#    apt install -y unzip
 
 RUN mkdir /tmp/tackle-ui-tests
 WORKDIR /tmp/tackle-ui-tests


### PR DESCRIPTION
This PR removes the installation of unzip, it is no longer needed and is breaking the image
