### PR TITLE
[RFR] Increase timeout while querying for kebab menu on Application Inventory page

### DIFF
--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -756,7 +756,9 @@ export function application_inventory_kebab_menu(menu: string): void {
     // The value for menu could be one of {Import, Manage imports, Delete, Manage credentials}
     navigate_to_application_inventory();
 
-    cy.get(actionButton).eq(0).click({ force: true });
+    cy.get(actionButton, { timeout: 60 * SEC })
+        .eq(0)
+        .click({ force: true });
     if (menu == "Import") {
         clickByText(button, "Import");
     } else {


### PR DESCRIPTION
On an all tier run on Jenkins, the import tests failed because the Application Inventory page wouldn't load . Hence, I'm increasing the timeout while querying for kebab menu on the Application Inventory page.

<!-- Add pull request description here -->

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
