### PR TITLE
[RFR] Wait for application tags tab to load

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -26,7 +26,7 @@ export default defineConfig({
         logLevel: "ASSERT",
     },
     retries: {
-        runMode: 2,
+        runMode: 0,
         openMode: 0,
     },
     reporter: "cypress-multi-reporters",

--- a/cypress/e2e/models/migration/applicationinventory/application.ts
+++ b/cypress/e2e/models/migration/applicationinventory/application.ts
@@ -362,7 +362,7 @@ export class Application {
         cy.get(rightSideMenu).within(() => {
             clickTab(tab);
         });
-        // Make sure application 'Tags' tab page is loaded before proceeding
+        // Make sure application 'Tags' tab page is loaded before proceeding with anything
         if ((tab = "Tags")) cy.get("div[class='pf-v5-c-toolbar__item']", { timeout: 60 * SEC });
     }
 

--- a/cypress/e2e/models/migration/applicationinventory/application.ts
+++ b/cypress/e2e/models/migration/applicationinventory/application.ts
@@ -362,6 +362,8 @@ export class Application {
         cy.get(rightSideMenu).within(() => {
             clickTab(tab);
         });
+        // Make sure 'Tags' tab page is loaded before proceeding
+        if ((tab = "Tags")) cy.get("div[class='pf-v5-c-toolbar__item']", { timeout: 60 * SEC });
     }
 
     closeApplicationDetails(): void {

--- a/cypress/e2e/models/migration/applicationinventory/application.ts
+++ b/cypress/e2e/models/migration/applicationinventory/application.ts
@@ -362,7 +362,7 @@ export class Application {
         cy.get(rightSideMenu).within(() => {
             clickTab(tab);
         });
-        // Make sure 'Tags' tab page is loaded before proceeding
+        // Make sure application 'Tags' tab page is loaded before proceeding
         if ((tab = "Tags")) cy.get("div[class='pf-v5-c-toolbar__item']", { timeout: 60 * SEC });
     }
 


### PR DESCRIPTION
<!-- Add pull request description here -->
The Application 'Tags' tab on the side drawer takes long to load . So, I've added a wait to make sure we proceed only after the 'Tags' tab is loaded.
This fixes the 'Automated tagging using Source Analysis on tackle testapp'  failure in analysis/source_analysis.test.ts 

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
