### PR TITLE
[RFR] Remove disabled button assertion for exported apps on migration waves

### DIFF
--- a/cypress/e2e/tests/migration/migration-waves/export_to_jira_cloud.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/export_to_jira_cloud.test.ts
@@ -145,19 +145,6 @@ describe(["@tier1"], "Export Migration Wave to Jira Cloud", function () {
                 });
 
                 Application.open();
-                appsMap[issueType].forEach((app) => {
-                    performRowActionByIcon(app.name, kebabMenu);
-                    cy.get(commonView.actionMenuItem)
-                        .contains("Delete")
-                        .closest(button)
-                        .then(($btn) => {
-                            expect(
-                                $btn,
-                                "Application with a linked Jira ticked could be deleted, this is probably a product bug"
-                            ).to.be.disabled;
-                        });
-                    performRowActionByIcon(app.name, kebabMenu);
-                });
 
                 jiraCloudInstance.deleteIssues(waveIssues.map((issue) => issue.id));
 


### PR DESCRIPTION
<!-- Add pull request description here -->

The assertion failed because devs changed the disabled attribute for an aria-disabled one. But the button won't be disabled in the future due to [MTA-2225](https://issues.redhat.com/browse/MTA-2225) so there is no need to keep the assertion.

Jenkins run [2284](https://main-jenkins-csb-migrationqe.apps.ocp-c1.prod.psi.redhat.com/view/MTA/job/mta/job/mta-ui-tests-runner/2284/)
![image](https://github.com/konveyor/tackle-ui-tests/assets/117646518/ac8ad82f-6e4d-4df8-826a-2504a0030b64)


<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
