### PR TITLE
[RFR] fix JF - migration waves unlink application test

### DIFF
--- a/cypress/e2e/models/migration/applicationinventory/application.ts
+++ b/cypress/e2e/models/migration/applicationinventory/application.ts
@@ -821,7 +821,7 @@ export class Application {
 
     unlinkJiraTicket(): void {
         Application.open();
-        this.applicationDetailsTab(details);
+        sidedrawerTab(this.name, "Details");
         cy.contains("small", "Ticket")
             .next()
             .children("div")

--- a/cypress/e2e/models/migration/applicationinventory/application.ts
+++ b/cypress/e2e/models/migration/applicationinventory/application.ts
@@ -821,7 +821,7 @@ export class Application {
 
     unlinkJiraTicket(): void {
         Application.open();
-        sidedrawerTab(this.name, "Details");
+        sidedrawerTab(this.name, details);
         cy.contains("small", "Ticket")
             .next()
             .children("div")


### PR DESCRIPTION
<!-- Add pull request description here -->
this.applicationDetailsTab(details); was causing the test to navigate to "Tags" tab instead of details
switched to sidedrawerTab(this.name, "Details");
jenkins [run](https://main-jenkins-csb-migrationqe.apps.ocp-c1.prod.psi.redhat.com/job/mta/job/mta-ui-tests-runner/2309/)
![image](https://github.com/konveyor/tackle-ui-tests/assets/132557033/206eb9a2-c80a-4e37-a23d-4e0b67169687)
 
<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
