### PR TITLE
[RFR] Use Cypress.env(mtaVersion) for pre-upgrade test

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -24,6 +24,7 @@ export default defineConfig({
         tackleUrl: "https://tackle-konveyor-tackle.apps.mtv03.rhos-psi.cnv-qe.rhood.us",
         rwx_enabled: true,
         logLevel: "ASSERT",
+        mtaVersion: "",
     },
     retries: {
         runMode: 0,

--- a/cypress/e2e/tests/upgrade/create_upgrade_data.test.ts
+++ b/cypress/e2e/tests/upgrade/create_upgrade_data.test.ts
@@ -44,7 +44,7 @@ describe(["@pre-upgrade"], "Creating pre-requisites before an upgrade", () => {
     let stakeHolder: Stakeholders;
     let archetype: Archetype;
     let stakeHolderGroup: Stakeholdergroups;
-    const expectedMtaVersion = Cypress.env("sourceMtaVersion");
+    const expectedMtaVersion = Cypress.env("mtaVersion");
 
     before("Login", function () {
         login();


### PR DESCRIPTION
Since pre-upgrade and post-upgrade tests are triggered in separate test runs - one before the upgrade procedure and one after - we can use the same environment value `mtaVersion`