### PR TITLE
[RFR][JF] Remove dc tag from custom-migration-targets test

### DIFF
--- a/cypress/e2e/tests/administration/custom-migration-targets/crud.test.ts
+++ b/cypress/e2e/tests/administration/custom-migration-targets/crud.test.ts
@@ -40,7 +40,7 @@ import { Analysis } from "../../../models/migration/applicationinventory/analysi
 import { cancelButton } from "../../../views/common.view";
 import * as commonView from "../../../views/common.view";
 
-describe(["@tier1", "@dc", "@interop"], "Custom Migration Targets CRUD operations", () => {
+describe(["@tier1", "@interop"], "Custom Migration Targets CRUD operations", () => {
     before("Login", function () {
         login();
     });

--- a/cypress/e2e/tests/rbac/custom-migration-target.test.ts
+++ b/cypress/e2e/tests/rbac/custom-migration-target.test.ts
@@ -40,7 +40,7 @@ import { UserArchitect } from "../../models/keycloak/users/userArchitect";
 import { UserMigrator } from "../../models/keycloak/users/userMigrator";
 import { User } from "../../models/keycloak/users/user";
 
-describe(["tier2", "@dc"], "1 Bug: Custom Migration Targets RBAC operations", function () {
+describe(["tier2"], "1 Bug: Custom Migration Targets RBAC operations", function () {
     // Polarion TC 317 & 319
     let analysis: Analysis;
     let target: CustomMigrationTarget;


### PR DESCRIPTION
The analysis for the Disconnected cluster is failing because it lacks external network access. Consequently, we've decided to remove the 'dc' tag from 'custom-migration-target.test.ts' and 'rbac/custom-migration-target.test.ts'.

I'm currently reviewing the upload binary analysis since it operates on the DC cluster. Consequently, those test cases will be marked with the 'dc' tag in another PR.