### PR TITLE
[RFR] Adding cypress-fail-fast plugin

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -25,6 +25,8 @@ export default defineConfig({
         rwx_enabled: true,
         logLevel: "ASSERT",
         mtaVersion: "",
+        FAIL_FAST_PLUGIN: true,
+        FAIL_FAST_ENABLED: false,
     },
     retries: {
         runMode: 0,
@@ -51,6 +53,8 @@ export default defineConfig({
         setupNodeEvents(on, config) {
             require("./cypress/plugins/index.js")(on, config);
             on("file:preprocessor", tagify(config));
+            require("cypress-fail-fast/plugin")(on, config);
+            return config;
         },
         experimentalMemoryManagement: true,
         numTestsKeptInMemory: 15,

--- a/cypress/e2e/tests/upgrade/after_upgrade.test.ts
+++ b/cypress/e2e/tests/upgrade/after_upgrade.test.ts
@@ -46,15 +46,11 @@ import { legacyPathfinder } from "../../types/constants";
 import { Application } from "../../models/migration/applicationinventory/application";
 import { Archetype } from "../../models/migration/archetypes/archetype";
 
-describe(["@post-upgrade"], "Performing post-upgrade validations", () => {
+describe(["@post-upgrade"], "Performing post-upgrade validations", { failFast: { enabled: true } }, () => {
     const expectedMtaVersion = Cypress.env("mtaVersion");
     before("Login", function () {
         // Perform login
         login();
-        validateMtaVersionInCLI(expectedMtaVersion);
-        validateTackleCr();
-        validateTackleOperatorLog();
-        validateMtaVersionInUI(expectedMtaVersion);
         AssessmentQuestionnaire.enable(legacyPathfinder);
     });
 
@@ -69,6 +65,14 @@ describe(["@post-upgrade"], "Performing post-upgrade validations", () => {
             this.upgradeData = upgradeData;
         });
     });
+
+        it("Validate MTA version in UI", () => validateMtaVersionInUI(expectedMtaVersion));
+
+        it("Validate MTA version in CLI", () => validateMtaVersionInCLI(expectedMtaVersion));
+
+        it("Validate Tackle CR", () => validateTackleCr());
+
+        it("Validate Tackle Operator Log", () => validateTackleOperatorLog());
 
     it("Controls - testing existence of instances created before upgrade", function () {
         const {

--- a/cypress/e2e/tests/upgrade/after_upgrade.test.ts
+++ b/cypress/e2e/tests/upgrade/after_upgrade.test.ts
@@ -46,7 +46,7 @@ import { legacyPathfinder } from "../../types/constants";
 import { Application } from "../../models/migration/applicationinventory/application";
 import { Archetype } from "../../models/migration/archetypes/archetype";
 
-describe(["@post-upgrade"], "Performing post-upgrade validations", { failFast: { enabled: true } }, () => {
+describe(["@post-upgrade"], "Performing post-upgrade validations", () => {
     const expectedMtaVersion = Cypress.env("mtaVersion");
     before("Login", function () {
         // Perform login
@@ -66,13 +66,15 @@ describe(["@post-upgrade"], "Performing post-upgrade validations", { failFast: {
         });
     });
 
-        it("Validate MTA version in UI", () => validateMtaVersionInUI(expectedMtaVersion));
+    it("Validate MTA version in UI", { failFast: { enabled: true } }, () =>
+        validateMtaVersionInUI(expectedMtaVersion)
+    );
 
-        it("Validate MTA version in CLI", () => validateMtaVersionInCLI(expectedMtaVersion));
+    it("Validate MTA version in CLI", () => validateMtaVersionInCLI(expectedMtaVersion));
 
-        it("Validate Tackle CR", () => validateTackleCr());
+    it("Validate Tackle CR", () => validateTackleCr());
 
-        it("Validate Tackle Operator Log", () => validateTackleOperatorLog());
+    it("Validate Tackle Operator Log", () => validateTackleOperatorLog());
 
     it("Controls - testing existence of instances created before upgrade", function () {
         const {

--- a/cypress/e2e/tests/upgrade/after_upgrade.test.ts
+++ b/cypress/e2e/tests/upgrade/after_upgrade.test.ts
@@ -66,6 +66,7 @@ describe(["@post-upgrade"], "Performing post-upgrade validations", () => {
         });
     });
 
+    // Enable fail fast, skip the rest of tests if this specific test fails.
     it("Validate MTA version in UI", { failFast: { enabled: true } }, () =>
         validateMtaVersionInUI(expectedMtaVersion)
     );

--- a/cypress/e2e/tests/upgrade/create_upgrade_data.test.ts
+++ b/cypress/e2e/tests/upgrade/create_upgrade_data.test.ts
@@ -38,7 +38,7 @@ import { CredentialsMaven } from "../../models/administration/credentials/creden
 import { AssessmentQuestionnaire } from "../../models/administration/assessment_questionnaire/assessment_questionnaire";
 import { Archetype } from "../../models/migration/archetypes/archetype";
 
-describe(["@pre-upgrade"], "Creating pre-requisites before an upgrade", () => {
+describe(["@pre-upgrade"], "Creating pre-requisites before an upgrade", { failFast: { enabled: true } }, () => {
     let mavenCredentialsUsername: CredentialsMaven;
     let sourceControlUsernameCredentials: CredentialsSourceControlUsername;
     let stakeHolder: Stakeholders;
@@ -48,8 +48,6 @@ describe(["@pre-upgrade"], "Creating pre-requisites before an upgrade", () => {
 
     before("Login", function () {
         login();
-        validateMtaVersionInUI(expectedMtaVersion);
-        validateMtaVersionInCLI(expectedMtaVersion);
         AssessmentQuestionnaire.enable(legacyPathfinder);
     });
 
@@ -66,6 +64,10 @@ describe(["@pre-upgrade"], "Creating pre-requisites before an upgrade", () => {
 
         cy.intercept("GET", "/hub/application*").as("getApplication");
     });
+
+        it("Validate MTA version in UI", () => validateMtaVersionInUI(expectedMtaVersion));
+
+        it("Validate MTA version in CLI", () => validateMtaVersionInCLI(expectedMtaVersion));
 
     it("Creating credentials", function () {
         const { sourceControlUsernameCredentialsName, mavenUsernameCredentialName } =

--- a/cypress/e2e/tests/upgrade/create_upgrade_data.test.ts
+++ b/cypress/e2e/tests/upgrade/create_upgrade_data.test.ts
@@ -65,6 +65,7 @@ describe(["@pre-upgrade"], "Creating pre-requisites before an upgrade", () => {
         cy.intercept("GET", "/hub/application*").as("getApplication");
     });
 
+    // Enable fail fast, skip the rest of tests if this specific test fails.
     it("Validate MTA version in UI", { failFast: { enabled: true } }, () =>
         validateMtaVersionInUI(expectedMtaVersion)
     );

--- a/cypress/e2e/tests/upgrade/create_upgrade_data.test.ts
+++ b/cypress/e2e/tests/upgrade/create_upgrade_data.test.ts
@@ -38,7 +38,7 @@ import { CredentialsMaven } from "../../models/administration/credentials/creden
 import { AssessmentQuestionnaire } from "../../models/administration/assessment_questionnaire/assessment_questionnaire";
 import { Archetype } from "../../models/migration/archetypes/archetype";
 
-describe(["@pre-upgrade"], "Creating pre-requisites before an upgrade", { failFast: { enabled: true } }, () => {
+describe(["@pre-upgrade"], "Creating pre-requisites before an upgrade", () => {
     let mavenCredentialsUsername: CredentialsMaven;
     let sourceControlUsernameCredentials: CredentialsSourceControlUsername;
     let stakeHolder: Stakeholders;
@@ -65,9 +65,11 @@ describe(["@pre-upgrade"], "Creating pre-requisites before an upgrade", { failFa
         cy.intercept("GET", "/hub/application*").as("getApplication");
     });
 
-        it("Validate MTA version in UI", () => validateMtaVersionInUI(expectedMtaVersion));
+    it("Validate MTA version in UI", { failFast: { enabled: true } }, () =>
+        validateMtaVersionInUI(expectedMtaVersion)
+    );
 
-        it("Validate MTA version in CLI", () => validateMtaVersionInCLI(expectedMtaVersion));
+    it("Validate MTA version in CLI", () => validateMtaVersionInCLI(expectedMtaVersion));
 
     it("Creating credentials", function () {
         const { sourceControlUsernameCredentialsName, mavenUsernameCredentialName } =

--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -34,6 +34,9 @@ import "./commands";
 //Cypress-react-selector
 import "cypress-react-selector";
 
+// For more information, see: https://github.com/javierbrea/cypress-fail-fast/blob/main/README.md
+import "cypress-fail-fast";
+
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
 require("cypress-xpath"); // Refer - https://www.npmjs.com/package/cypress-xpath

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
                 "cy-verify-downloads": "^0.1.13",
                 "cypress": "^13.6.4",
                 "cypress-downloadfile": "^1.2.3",
+                "cypress-fail-fast": "^7.1.0",
                 "cypress-mochawesome-reporter": "^3.2.2",
                 "cypress-tags": "^1.1.2",
                 "license-check-and-add": "^4.0.5",
@@ -3845,6 +3846,21 @@
             "integrity": "sha512-sp1dILmN8HXCUIeeztqlCslyghFT5w1gHM7RFA/AUSLKmDI/ovxNhZQI6U2/cbH2ehbCuvPppyh99uEt9dhF3w==",
             "deprecated": "This package has been moved to https://www.npmjs.com/package/@4tw/cypress-drag-drop."
         },
+        "node_modules/cypress-fail-fast": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/cypress-fail-fast/-/cypress-fail-fast-7.1.0.tgz",
+            "integrity": "sha512-OnN5WqSP49yHKoitq+FmMG/+nUvat6NdFLNUQgVJYbmDdgyiiS1aI33S8+AuRb4zRZR5+5/eq53p/oL+a/m2Tw==",
+            "dev": true,
+            "dependencies": {
+                "chalk": "4.1.2"
+            },
+            "engines": {
+                "node": ">=14.0.0"
+            },
+            "peerDependencies": {
+                "cypress": ">=8.0.0"
+            }
+        },
         "node_modules/cypress-file-upload": {
             "version": "5.0.8",
             "resolved": "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-5.0.8.tgz",
@@ -4683,19 +4699,6 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
             "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw=="
-        },
-        "node_modules/fsevents": {
-            "version": "2.3.3",
-            "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
-            "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
-            "hasInstallScript": true,
-            "optional": true,
-            "os": [
-                "darwin"
-            ],
-            "engines": {
-                "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-            }
         },
         "node_modules/fsu": {
             "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
         "cy-verify-downloads": "^0.1.13",
         "cypress": "^13.6.4",
         "cypress-downloadfile": "^1.2.3",
+        "cypress-fail-fast": "^7.1.0",
         "cypress-mochawesome-reporter": "^3.2.2",
         "cypress-tags": "^1.1.2",
         "license-check-and-add": "^4.0.5",


### PR DESCRIPTION
Enables fail fast in Cypress, skipping the rest of tests if `Validate MTA version in UI` test fails.
[Jenkins run](https://main-jenkins-csb-migrationqe.apps.ocp-c1.prod.psi.redhat.com/view/MTA/job/mta/job/mta-ui-tests-runner/2737/consoleFull)

For more information, see: https://github.com/javierbrea/cypress-fail-fast/blob/main/README.md

Resolves: https://issues.redhat.com/browse/MTA-2475