### PR TITLE
[RFR] Verify app Assessment and Review get reset when archetype assessment/review is discarded'

### DIFF
--- a/cypress/e2e/tests/migration/applicationinventory/assessment/archetype_association.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/assessment/archetype_association.test.ts
@@ -155,9 +155,9 @@ describe(["@tier2"], "Tests related to application-archetype association ", () =
         for (let i = 0; i < archetypeList.length; i++) {
             archetypeList[i].discard("Discard review");
             archetypeList[i].discard("Discard assessment(s)");
-            application2.verifyStatus("assessment", "Not started");
-            application2.verifyStatus("review", "Not started");
         }
+        application2.verifyStatus("assessment", "Not started");
+        application2.verifyStatus("review", "Not started");
 
         deleteByList(archetypeList);
     });

--- a/cypress/e2e/tests/migration/applicationinventory/assessment/archetype_association.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/assessment/archetype_association.test.ts
@@ -149,6 +149,16 @@ describe(["@tier2"], "Tests related to application-archetype association ", () =
         application2.verifyArchetypeList(archetypeNames, "Archetypes assessed");
         application2.validateAssessmentField("Medium");
         application2.verifyInheritanceStatus("assessment");
+
+        // Application Assessment and Review status should show 'Not started' when
+        // archetype assessment and review are discarded.
+        for (let i = 0; i < archetypeList.length; i++) {
+            archetypeList[i].discard("Discard review");
+            archetypeList[i].discard("Discard assessment(s)");
+            application2.verifyStatus("assessment", "Not started");
+            application2.verifyStatus("review", "Not started");
+        }
+
         deleteByList(archetypeList);
     });
 

--- a/cypress/e2e/tests/migration/archetypes/crud.test.ts
+++ b/cypress/e2e/tests/migration/archetypes/crud.test.ts
@@ -122,35 +122,6 @@ describe(["@tier1"], "Archetype CRUD operations", () => {
         notExists(archetypeDuplicate.name);
     });
 
-    it("Discard archetype review", function () {
-        // Automates Polarion MTA-428
-
-        const archetype = new Archetype(
-            data.getRandomWord(8),
-            [tags[0].name],
-            [tags[1].name],
-            null,
-            stakeholders,
-            stakeholderGroups
-        );
-
-        archetype.create();
-        exists(archetype.name);
-
-        archetype.perform_review("high");
-        cy.wait(2 * SEC);
-        archetype.validateReviewFields();
-
-        archetype.discard("Discard review");
-        cy.wait(2 * SEC);
-        archetype.validateNotReviewed();
-
-        cy.wait(2 * SEC);
-        archetype.delete();
-
-        notExists(archetype.name);
-    });
-
     after("Clear test data", function () {
         deleteByList(stakeholders);
         deleteByList(stakeholderGroups);

--- a/cypress/e2e/tests/migration/archetypes/miscellaneous.test.ts
+++ b/cypress/e2e/tests/migration/archetypes/miscellaneous.test.ts
@@ -62,6 +62,7 @@ describe(["@tier3"], "Miscellaneous Archetype tests", () => {
         cy.wait(2 * SEC);
         archetype.perform_assessment("high", stakeholderList, null, cloudReadinessQuestionnaire);
         archetype.validateAssessmentField("High");
+        archetype.perform_review("high");
     });
 
     it("Retake questionnaire for Archetype", function () {
@@ -123,6 +124,18 @@ describe(["@tier3"], "Miscellaneous Archetype tests", () => {
             true
         );
         archetype.validateAssessmentField("Unknown");
+    });
+
+    it("Discard archetype review", function () {
+        // Automates Polarion MTA-428
+        archetype.discard("Discard review");
+        checkSuccessAlert(
+            successAlertMessage,
+            `Success! Review discarded for ${archetype.name}.`,
+            true
+        );
+        cy.wait(2 * SEC);
+        archetype.validateNotReviewed();
     });
 
     after("Perform test data clean up", function () {


### PR DESCRIPTION
1) Added an additional check to verify application  Assessment and Review get reset when archetype assessment/review 
is discarded
2) Moved Archetype assessment discard test
 

<!-- Add pull request description here -->

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
