### PR TITLE
[RFR] Fix selecting language on analysis wizard, targets step

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,7 @@ LICENSE
 node_modules
 *.md
 license-checker-config.json
+
+cypress/downloads/
+cypress/reports/
+cypress/screenshots/

--- a/cypress/e2e/models/migration/applicationinventory/analysis.ts
+++ b/cypress/e2e/models/migration/applicationinventory/analysis.ts
@@ -163,10 +163,21 @@ export class Analysis extends Application {
         selectFormItems(sourceDropdown, source);
     }
 
+    /**
+     * Make sure our language is selected. It may already be selected if language-discovery
+     * added it, or if it was added manually.
+     */
     public static selectLanguage(language: Languages) {
         cy.wait(2 * SEC);
         click(actionSelectToggle);
-        clickByText("div", language);
+
+        // find the language's input checkbox and make sure it is checked
+        cy.get(`${actionSelectToggle} + .pf-v5-c-menu`)
+            .contains(language)
+            .closest(".pf-v5-c-menu__list-item")
+            .find("input[type=checkbox]")
+            .check();
+
         click(actionSelectToggle);
     }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,7 @@
         "skipLibCheck": true,
         "allowJs": true,
         "resolveJsonModule": true,
-        "sourceMap": true,
+        "sourceMap": true
     },
     "typedocOptions": {
         "entryPoints": ["cypress/integration"],


### PR DESCRIPTION
Follow-up to #1136

To make sure the test does not unselected the desired target language that is automatically selected from the application's tags (language-discovery automatically adds tags when the application is created), switch from a `click()` action to a `check()` action.  A bit more code is used to get to the input checkbox so the `check()` will work.

Note 1: This only became an issue on the test after the 0.5 alpha release when the language-discovery tasks started running consistently and accurately.

Note 2: Updated the `.prettierignore` to exclude the cypress run generated files from checking. Devs won't need to ignore style warnings on mocha json reports anymore.