### PR TITLE
[RFR] Added Go analysis support and use in custom migration targets tests

### DIFF
--- a/cypress/e2e/models/migration/applicationinventory/analysis.ts
+++ b/cypress/e2e/models/migration/applicationinventory/analysis.ts
@@ -166,9 +166,19 @@ export class Analysis extends Application {
      * Make sure our language is selected. It may already be selected if language-discovery
      * added it, or if it was added manually.
      */
-    public static selectLanguage(language: Languages) {
+    public static selectLanguage(language: Languages, removePreSelected = false) {
         cy.wait(2 * SEC);
         click(actionSelectToggle);
+
+        if (removePreSelected) {
+            cy.get("#filter-by-language input[type=checkbox]").each(($checkbox) => {
+                cy.wrap($checkbox).then((checkbox) => {
+                    if (checkbox.is(":checked")) {
+                        cy.wrap($checkbox).uncheck();
+                    }
+                });
+            });
+        }
 
         // find the language's input checkbox and make sure it is checked
         cy.get(`${actionSelectToggle} + .pf-v5-c-menu`)
@@ -180,7 +190,7 @@ export class Analysis extends Application {
         click(actionSelectToggle);
     }
 
-    protected selectTarget(target: string[]): void {
+    public selectTarget(target: string[]): void {
         for (let i = 0; i < target.length; i++) {
             if (["OpenJDK 11", "OpenJDK 17", "OpenJDK 21"].includes(target[i])) {
                 click(openjdkToggleButton);

--- a/cypress/e2e/tests/administration/custom-migration-targets/crud.test.ts
+++ b/cypress/e2e/tests/administration/custom-migration-targets/crud.test.ts
@@ -245,7 +245,7 @@ describe(["@tier1", "@interop"], "Custom Migration Targets CRUD operations", () 
                 application.delete();
             });
 
-            it("ustom rule with source and target technology", function () {
+            it("Custom rule with source and target technology", function () {
                 const targetData = this.customMigrationTargets["rules_with_source_target_element"];
                 const target = new CustomMigrationTarget(
                     data.getRandomWord(8),

--- a/cypress/e2e/tests/administration/custom-migration-targets/crud.test.ts
+++ b/cypress/e2e/tests/administration/custom-migration-targets/crud.test.ts
@@ -22,6 +22,7 @@ import {
     getRandomAnalysisData,
     getRandomApplicationData,
     login,
+    next,
     selectItemsPerPage,
 } from "../../../../utils/utils";
 import {
@@ -42,248 +43,255 @@ import { cancelButton } from "../../../views/common.view";
 import * as commonView from "../../../views/common.view";
 
 describe(["@tier1", "@interop"], "Custom Migration Targets CRUD operations", () => {
+    let appFixture: string;
+    let analysisFixture: string;
+    let languageLower: string;
+
     before("Login", function () {
         login();
     });
 
-    // Automates Polarion TC 300 & 305
-    beforeEach("Fixtures and Interceptors", function () {
-        cy.fixture("custom-rules").then(function (customMigrationTargets) {
-            this.customMigrationTargets = customMigrationTargets;
-        });
-
-        cy.fixture("application").then(function (appData) {
-            this.appData = appData;
-        });
-
-        cy.fixture("analysis").then(function (analysisData) {
-            this.analysisData = analysisData;
-        });
-
-        cy.intercept("POST", "/hub/targets/*").as("postRule");
-        cy.intercept("GET", "/hub/targets*").as("getRule");
-        cy.intercept("PUT", "/hub/targets*/*").as("putRule");
-        cy.intercept("DELETE", "/hub/targets*/*").as("deleteRule");
-
-        CustomMigrationTarget.open(true);
-    });
-
     Object.values(Languages).forEach((language) => {
-        it(`${language} | Custom Migration Targets CRUD with rules uploaded manually`, function () {
-            const targetData = this.customMigrationTargets["manual_rules"];
-            const target = new CustomMigrationTarget(
-                data.getRandomWord(8),
-                data.getDescription(),
-                targetData.image,
-                getRulesData(targetData),
-                language
-            );
-            target.create();
-            cy.wait(2 * SEC);
-            cy.contains(CustomMigrationTargetView.takeMeThereNotification).click();
-            closeSuccessAlert();
-            cy.get(CustomMigrationTargetView.card, { timeout: 12 * SEC }).should(
-                "contain",
-                target.name
-            );
+        describe(`${language} language`, function () {
+            // Automates Polarion TC 300 & 305
 
-            const newName = data.getRandomWord(8);
-            const newRules = {
-                ...target.ruleTypeData,
-                rulesetPaths: ["xml/javax-package-custom.windup.xml"],
-            };
+            beforeEach("Fixtures and Interceptors", function () {
+                appFixture = "application";
+                analysisFixture = "analysis";
+                languageLower = language.toLowerCase();
 
-            target.edit({
-                name: newName,
-                ruleTypeData: newRules,
-            });
-            cy.get(CustomMigrationTargetView.card, { timeout: 12 * SEC }).should(
-                "contain",
-                newName
-            );
-            target.name = newName;
-            target.ruleTypeData = newRules;
-
-            target.delete();
-            cy.wait("@deleteRule");
-            cy.wait(3 * SEC);
-            cy.get(CustomMigrationTargetView.cardContainer).then((container) => {
-                if (container.children().length > 1) {
-                    cy.get(CustomMigrationTargetView.card, { timeout: 12 * SEC }).should(
-                        "not.contain",
-                        target.name
-                    );
+                if (language !== Languages.Java) {
+                    appFixture = `${languageLower}-application`;
+                    analysisFixture = `${languageLower}-analysis`;
                 }
-            });
-        });
-    });
 
-    Object.values(Languages).forEach((language) => {
-        it(`${language} | Create Custom Migration Target with rules from repository with credentials`, function () {
-            const sourceCredential = new CredentialsSourceControlUsername(
-                data.getRandomCredentialsData(
-                    CredentialType.sourceControl,
-                    UserCredentials.usernamePassword,
-                    Cypress.env("git_password") && Cypress.env("git_user")
-                )
-            );
+                cy.fixture(appFixture).then(function (appData) {
+                    this.appData = appData;
+                });
 
-            sourceCredential.create();
-            const targetData = this.customMigrationTargets["rules_from_tackle_testApp"];
-            const repositoryData = {
-                ...getRulesData(targetData),
-                credentials: sourceCredential,
-            };
+                cy.fixture(analysisFixture).then(function (analysisData) {
+                    this.analysisData = analysisData;
+                });
 
-            const target = new CustomMigrationTarget(
-                data.getRandomWord(8),
-                data.getDescription(),
-                targetData.image,
-                repositoryData,
-                language
-            );
+                cy.fixture("custom-rules").then(function (customMigrationTargets) {
+                    this.customMigrationTargets = customMigrationTargets;
+                });
 
-            target.create();
-            cy.contains(CustomMigrationTargetView.takeMeThereNotification).click();
-            closeSuccessAlert();
-            cy.get(CustomMigrationTargetView.card, { timeout: 12 * SEC }).should(
-                "contain",
-                target.name
-            );
+                cy.intercept("POST", "/hub/targets/*").as("postRule");
+                cy.intercept("GET", "/hub/targets*").as("getRule");
+                cy.intercept("PUT", "/hub/targets*/*").as("putRule");
+                cy.intercept("DELETE", "/hub/targets*/*").as("deleteRule");
 
-            // TC MTA-403
-            target.openEditDialog();
-            cy.get(CustomMigrationTargetView.credentialsInput).should(
-                "have.value",
-                sourceCredential.name
-            );
-            click(cancelButton);
-
-            target.delete();
-            sourceCredential.delete();
-        });
-    });
-
-    Object.values(Languages).forEach((language) => {
-        it(`${
-            language === Languages.Go ? "Bug MTA-3308:" : ""
-        } ${language} | Change layout and check in analysis wizard`, function () {
-            const targetData = this.customMigrationTargets["manual_rules"];
-            const target = new CustomMigrationTarget(
-                data.getRandomWord(8),
-                data.getDescription(),
-                targetData.image,
-                getRulesData(targetData),
-                language
-            );
-            target.create();
-
-            const target1 = new CustomMigrationTarget(
-                data.getRandomWord(8),
-                data.getDescription(),
-                targetData.image,
-                getRulesData(targetData),
-                language
-            );
-            // Two targets are required for Go to drag and change position.
-            if (language == Languages.Go) {
-                target1.create();
-            }
-            closeSuccessAlert();
-
-            const dragButton = cy
-                .contains(CustomMigrationTargetView.card, target.name, { timeout: 12 * SEC })
-                .find(CustomMigrationTargetView.dragButton);
-
-            // Moves the custom migration target to the first place
-            cy.wait("@getRule");
-            dragButton.drag(commonView.optionMenu, {
-                force: true,
-                waitForAnimations: false,
+                CustomMigrationTarget.open(true);
             });
 
-            Analysis.open(true);
-            const application = new Analysis(
-                getRandomApplicationData("bookserverApp", {
-                    sourceData: this.appData["bookserver-app"],
-                }),
-                getRandomAnalysisData(this.analysisData["source_analysis_on_bookserverapp"])
-            );
-            application.create();
+            it("Custom Migration Targets CRUD with rules uploaded manually", function () {
+                const targetData = this.customMigrationTargets[`${languageLower}_manual_rules`];
+                const target = new CustomMigrationTarget(
+                    data.getRandomWord(8),
+                    data.getDescription(),
+                    targetData.image,
+                    getRulesData(targetData),
+                    language
+                );
+                target.create();
+                cy.wait(2 * SEC);
+                cy.contains(CustomMigrationTargetView.takeMeThereNotification).click();
+                closeSuccessAlert();
+                cy.get(CustomMigrationTargetView.card, { timeout: 12 * SEC }).should(
+                    "contain",
+                    target.name
+                );
 
-            Analysis.open();
-            selectItemsPerPage(100);
-            application.selectApplication();
-            cy.contains(button, analyzeButton, { timeout: 20 * SEC })
-                .should("be.enabled")
-                .click();
+                const newName = data.getRandomWord(8);
+                const newRules = {
+                    ...target.ruleTypeData,
+                    rulesetPaths: ["xml/javax-package-custom.windup.xml"],
+                };
 
-            application.selectSourceofAnalysis(application.source);
-            cy.contains(button, "Next", { timeout: 200 }).click();
+                target.edit({
+                    name: newName,
+                    ruleTypeData: newRules,
+                });
+                cy.get(CustomMigrationTargetView.card, { timeout: 12 * SEC }).should(
+                    "contain",
+                    newName
+                );
+                target.name = newName;
+                target.ruleTypeData = newRules;
 
-            Analysis.selectLanguage(language);
-            cy.get(".pf-v5-c-card__body", { timeout: 12 * SEC })
-                .first()
-                .should("contain", target.name);
-            clickByText(button, "Cancel");
+                target.delete();
+                cy.wait("@deleteRule");
+                cy.wait(3 * SEC);
+                cy.get(CustomMigrationTargetView.cardContainer).then((container) => {
+                    if (container.children().length > 1) {
+                        cy.get(CustomMigrationTargetView.card, { timeout: 12 * SEC }).should(
+                            "not.contain",
+                            target.name
+                        );
+                    }
+                });
+            });
 
-            target.delete();
-            if (language == Languages.Go) {
-                target1.delete();
-            }
-            application.delete();
-        });
-    });
+            it("Create Custom Migration Target with rules from repository with credentials", function () {
+                const sourceCredential = new CredentialsSourceControlUsername(
+                    data.getRandomCredentialsData(
+                        CredentialType.sourceControl,
+                        UserCredentials.usernamePassword,
+                        Cypress.env("git_password") && Cypress.env("git_user")
+                    )
+                );
 
-    Object.values(Languages).forEach((language) => {
-        it(`${language} | custom rule with source and target technology`, function () {
-            const targetData = this.customMigrationTargets["rules_with_source_target_element"];
-            const target = new CustomMigrationTarget(
-                data.getRandomWord(8),
-                data.getDescription(),
-                targetData.image,
-                getRulesData(targetData),
-                language,
-                targetData.sources
-            );
-            target.create();
-            closeSuccessAlert();
+                sourceCredential.create();
+                const targetData = this.customMigrationTargets["rules_from_tackle_testApp"];
+                const repositoryData = {
+                    ...getRulesData(targetData),
+                    credentials: sourceCredential,
+                };
 
-            const application = new Analysis(
-                getRandomApplicationData("bookserverApp", {
-                    sourceData: this.appData["bookserver-app"],
-                }),
-                getRandomAnalysisData(this.analysisData["source_analysis_on_bookserverapp"])
-            );
-            application.create();
+                const target = new CustomMigrationTarget(
+                    data.getRandomWord(8),
+                    data.getDescription(),
+                    targetData.image,
+                    repositoryData,
+                    language
+                );
 
-            // TC MTA-404
-            Analysis.open();
-            selectItemsPerPage(100);
-            application.selectApplication();
-            cy.contains(button, analyzeButton, { timeout: 20 * SEC })
-                .should("be.enabled")
-                .click();
+                target.create();
+                cy.contains(CustomMigrationTargetView.takeMeThereNotification).click();
+                closeSuccessAlert();
+                cy.get(CustomMigrationTargetView.card, { timeout: 12 * SEC }).should(
+                    "contain",
+                    target.name
+                );
 
-            application.selectSourceofAnalysis(application.source);
-            cy.contains(button, "Next", { timeout: 200 }).click();
+                // TC MTA-403
+                target.openEditDialog();
+                cy.get(CustomMigrationTargetView.credentialsInput).should(
+                    "have.value",
+                    sourceCredential.name
+                );
+                click(cancelButton);
 
-            Analysis.selectLanguage(language);
-            cy.get("div.pf-v5-c-empty-state__content", { timeout: 12 * SEC })
-                .contains(target.name)
-                .click();
-            cy.contains(button, "Next", { timeout: 200 }).click();
-            cy.contains(button, "Next", { timeout: 200 }).click();
-            cy.contains(button, "Next", { timeout: 200 }).click();
+                target.delete();
+                sourceCredential.delete();
+            });
 
-            target.validateSourceTechnology(targetData.sources);
+            it("Change layout and check in analysis wizard", function () {
+                const targetData = this.customMigrationTargets[`${languageLower}_manual_rules`];
+                const target = new CustomMigrationTarget(
+                    data.getRandomWord(8),
+                    data.getDescription(),
+                    targetData.image,
+                    getRulesData(targetData),
+                    language
+                );
+                target.create();
 
-            // TC 405 - Validate Target technology
-            cy.get(".pf-v5-c-wizard__main-body").should("contain", targetData.targets);
-            clickByText(button, "Cancel");
+                const target1 = new CustomMigrationTarget(
+                    data.getRandomWord(8),
+                    data.getDescription(),
+                    targetData.image,
+                    getRulesData(targetData),
+                    language
+                );
+                // Two targets are required for Go to drag and change position.
+                if (language == Languages.Go) {
+                    target1.create();
+                }
+                closeSuccessAlert();
 
-            target.delete();
-            application.delete();
+                const dragButton = cy
+                    .contains(CustomMigrationTargetView.card, target.name, { timeout: 12 * SEC })
+                    .find(CustomMigrationTargetView.dragButton);
+
+                // Moves the custom migration target to the first place
+                cy.wait("@getRule");
+                dragButton.drag(commonView.optionMenu, {
+                    force: true,
+                    waitForAnimations: false,
+                });
+
+                Analysis.open(true);
+                const application = new Analysis(
+                    getRandomApplicationData("", {
+                        sourceData: this.appData[`${languageLower}-example-app`],
+                    }),
+                    getRandomAnalysisData(this.analysisData["source_analysis"])
+                );
+                application.create();
+
+                Analysis.open();
+                selectItemsPerPage(100);
+                application.selectApplication();
+                cy.contains(button, analyzeButton, { timeout: 20 * SEC })
+                    .should("be.enabled")
+                    .click();
+
+                application.selectSourceofAnalysis(application.source);
+                cy.contains(button, "Next", { timeout: 200 }).click();
+
+                // Make sure the new custom migration target is in the first position
+                Analysis.selectLanguage(language, true);
+                cy.get(".pf-v5-c-card__body", { timeout: 12 * SEC })
+                    .first()
+                    .should("contain", target.name);
+                clickByText(button, "Cancel");
+
+                target.delete();
+                if (language == Languages.Go) {
+                    target1.delete();
+                }
+                application.delete();
+            });
+
+            it("ustom rule with source and target technology", function () {
+                const targetData = this.customMigrationTargets["rules_with_source_target_element"];
+                const target = new CustomMigrationTarget(
+                    data.getRandomWord(8),
+                    data.getDescription(),
+                    targetData.image,
+                    getRulesData(targetData),
+                    language,
+                    targetData.sources
+                );
+                target.create();
+                closeSuccessAlert();
+
+                const application = new Analysis(
+                    getRandomApplicationData("", {
+                        sourceData: this.appData[`${languageLower}-example-app`],
+                    }),
+                    getRandomAnalysisData(this.analysisData["source_analysis"])
+                );
+                application.create();
+
+                // TC MTA-404
+                Analysis.open();
+                selectItemsPerPage(100);
+                application.selectApplication();
+                cy.contains(button, analyzeButton, { timeout: 20 * SEC })
+                    .should("be.enabled")
+                    .click();
+
+                application.selectSourceofAnalysis(application.source);
+                cy.contains(button, "Next", { timeout: 200 }).click();
+
+                Analysis.selectLanguage(language);
+                application.selectTarget([target.name]);
+                next();
+                next();
+                next();
+
+                target.validateSourceTechnology(targetData.sources);
+
+                // TC 405 - Validate Target technology
+                cy.get(".pf-v5-c-wizard__main-body").should("contain", targetData.targets);
+                clickByText(button, "Cancel");
+
+                target.delete();
+                application.delete();
+            });
         });
     });
 });

--- a/cypress/fixtures/analysis.json
+++ b/cypress/fixtures/analysis.json
@@ -1,4 +1,9 @@
 {
+    "source_analysis": {
+        "source": "Source code",
+        "target": ["Containerization"],
+        "appName": "java-example-app"
+    },
     "source_analysis_on_bookserverapp": {
         "source": "Source code",
         "target": ["Containerization", "Linux", "Quarkus"],

--- a/cypress/fixtures/analysis.json
+++ b/cypress/fixtures/analysis.json
@@ -1,7 +1,7 @@
 {
     "source_analysis": {
         "source": "Source code",
-        "target": ["Containerization"],
+        "target": [],
         "appName": "java-example-app"
     },
     "source_analysis_on_bookserverapp": {

--- a/cypress/fixtures/application.json
+++ b/cypress/fixtures/application.json
@@ -67,5 +67,9 @@
     "Java_language_maven_tooling_quarkus_framework": {
         "repoType": "Git",
         "sourceRepo": "https://github.com/quarkusio/quarkus-super-heroes"
+    },
+    "java-example-app": {
+        "repoType": "Git",
+        "sourceRepo": "https://github.com/ibraginsky/book-server"
     }
 }

--- a/cypress/fixtures/custom-rules.json
+++ b/cypress/fixtures/custom-rules.json
@@ -1,5 +1,5 @@
 {
-    "manual_rules": {
+    "java_manual_rules": {
         "image": "img/cloud.png",
         "rulesFiles": ["xml/javax-package-custom-target.windup.xml"]
     },
@@ -31,5 +31,9 @@
         "rulesFiles": ["xml/corporate-framework-config.windup.xml"],
         "sources": ["traditional-corporate-framework"],
         "targets": ["cloud-corporate-framework"]
+    },
+    "go_manual_rules": {
+        "image": "img/cloud.png",
+        "rulesFiles": ["yaml/golang-dep-rules.yaml"]
     }
 }

--- a/cypress/fixtures/go-analysis.json
+++ b/cypress/fixtures/go-analysis.json
@@ -1,0 +1,14 @@
+{
+    "source_analysis": {
+        "source": "Source code",
+        "target": ["Containerization"],
+        "appName": "go-example-app"
+    },
+
+    "go_app_custom_rules": {
+        "source": "Source code + dependencies",
+        "target": [],
+        "appName": "golang-app",
+        "customRule": ["golang-dep-rules.yaml"]
+    }
+}

--- a/cypress/fixtures/go-analysis.json
+++ b/cypress/fixtures/go-analysis.json
@@ -1,14 +1,7 @@
 {
     "source_analysis": {
         "source": "Source code",
-        "target": ["Containerization"],
-        "appName": "go-example-app"
-    },
-
-    "go_app_custom_rules": {
-        "source": "Source code + dependencies",
         "target": [],
-        "appName": "golang-app",
-        "customRule": ["golang-dep-rules.yaml"]
+        "appName": "go-example-app"
     }
 }

--- a/cypress/fixtures/go-application.json
+++ b/cypress/fixtures/go-application.json
@@ -1,0 +1,7 @@
+{
+    "go-example-app": {
+        "repoType": "Git",
+        "sourceRepo": "https://github.com/konveyor/analyzer-lsp",
+        "rootPath": "examples/golang"
+    }
+}

--- a/cypress/fixtures/yaml/golang-dep-rules.yaml
+++ b/cypress/fixtures/yaml/golang-dep-rules.yaml
@@ -1,0 +1,39 @@
+- message: all go files
+  ruleID: file-001
+  description: "Testing that we can get all the go files in the project"
+  links:
+      - title: "Golang"
+        url: "https://go.dev"
+  labels:
+      - "testing"
+      - "test"
+  category: potential
+  effort: 3
+  when:
+      builtin.file:
+          pattern: "*.go"
+- message: not any go files
+  ruleID: file-002
+  when:
+      builtin.file:
+          pattern: "*.go"
+      not: true
+- message: "golang apiextensions/v1/customresourcedefinitions found {{file}}:{{lineNumber}}"
+  ruleID: go-lang-ref-001
+  when:
+      go.referenced:
+          pattern: "v1beta1.CustomResourceDefinition"
+- message: "dependency {{name}} with {{version}} is bad and you should feel bad for using it"
+  ruleID: golang-gomod-dependencies
+  when:
+      and:
+          - go.dependency:
+                name: golang.org/x/text
+                upperbound: v0.3.8
+          - go.dependency:
+                name: k8s.io/apimachinery
+                lowerbound: v0.24.3
+          - go.dependency:
+                name: sigs.k8s.io/structured-merge-diff/v4
+                lowerbound: v4.2.0
+                upperbound: v4.2.2


### PR DESCRIPTION
Important changes to review:
- Added fixtures
- Changes in `public static selectLanguage` - need it to test drag and drop target cards

I tried not to change the current implementation, but to use dynamic names to be able to run on different language than Java

Jenkins run: https://main-jenkins-csb-migrationqe.apps.ocp-c1.prod.psi.redhat.com/view/MTA/job/mta/job/mta-ui-tests-runner/3456/console