### PR TITLE
[RFR] Improve unlink test

### DIFF
--- a/cypress/e2e/tests/migration/migration-waves/unlink_application.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/unlink_application.test.ts
@@ -16,7 +16,16 @@ limitations under the License.
 /// <reference types="cypress" />
 
 import { createMultipleApplications, login } from "../../../../utils/utils";
-import { CredentialType, JiraIssueTypes, JiraType, SEC } from "../../../types/constants";
+import {
+    button,
+    CredentialType,
+    deleteAction,
+    JiraIssueTypes,
+    JiraType,
+    SEC,
+    tdTag,
+    trTag,
+} from "../../../types/constants";
 import * as data from "../../../../utils/data_utils";
 import { MigrationWave } from "../../../models/migration/migration-waves/migration-wave";
 import { Jira } from "../../../models/administration/jira-connection/jira";
@@ -85,7 +94,16 @@ describe(["@tier1"], "Unlink application from exported migration waves", functio
         exportWave().then(() => {
             migrationWave.clickWaveStatus();
             migrationWave.unlinkApplications(applications);
-            jiraCloudInstance.delete(true);
+            Jira.openList();
+            cy.get(tdTag)
+                .contains(jiraCloudInstance.name)
+                .closest(trTag)
+                .within(() => {
+                    cy.contains(button, deleteAction).should(
+                        "not.have.class",
+                        "pf-m-aria-disabled"
+                    );
+                });
         });
     });
 
@@ -93,7 +111,16 @@ describe(["@tier1"], "Unlink application from exported migration waves", functio
     it("Export to Jira Cloud and unlink applications from App Inventory", function () {
         exportWave().then(() => {
             applications.forEach((app) => app.unlinkJiraTicket());
-            jiraCloudInstance.delete(true);
+            Jira.openList();
+            cy.get(tdTag)
+                .contains(jiraCloudInstance.name)
+                .closest(trTag)
+                .within(() => {
+                    cy.contains(button, deleteAction).should(
+                        "not.have.class",
+                        "pf-m-aria-disabled"
+                    );
+                });
         });
     });
 

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -102,10 +102,7 @@ import {
     tagFilterName,
 } from "../e2e/views/issue.view";
 import { Archetype } from "../e2e/models/migration/archetypes/archetype";
-import {
-    MigrationWaveView,
-    getSpecialMigrationWavesTableSelector,
-} from "../e2e/views/migration-wave.view";
+import { MigrationWaveView } from "../e2e/views/migration-wave.view";
 import {
     codeEditorControls,
     manageCredentials,


### PR DESCRIPTION
<!-- Add pull request description here -->
Solves [MTA-3717](https://issues.redhat.com/browse/MTA-3717)

This test has been flacky for some time, the issue was when trying to delete the jira instance after unlinking an exported applications. Since the test doesn't have to delete de instance but just to check if the button is enabled, I updated the method to check just that without clicking anything.

![image](https://github.com/user-attachments/assets/c37cf435-a00c-4632-887b-2ec06d9de8bd)

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
