### PR TITLE
[RFR] Automate first gradle analysis

### DIFF
--- a/cypress/e2e/tests/migration/applicationinventory/analysis/gradle_analysis.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/analysis/gradle_analysis.ts
@@ -1,0 +1,71 @@
+/*
+Copyright © 2021 the Konveyor Contributors (https://konveyor.io/)
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+/// <reference types="cypress" />
+
+import {
+    login,
+    getRandomApplicationData,
+    deleteByList,
+    deleteAllMigrationWaves,
+    deleteApplicationTableRows,
+} from "../../../../../utils/utils";
+import { Analysis } from "../../../../models/migration/applicationinventory/analysis";
+import { AnalysisStatuses } from "../../../../types/constants";
+import { Application } from "../../../../models/migration/applicationinventory/application";
+
+const applications: Analysis[] = [];
+
+describe(["@tier2"], "Gradle Analysis", () => {
+    before("Login", function () {
+        login();
+        deleteAllMigrationWaves();
+        deleteApplicationTableRows();
+    });
+
+    beforeEach("Load data", function () {
+        cy.fixture("application").then(function (appData) {
+            this.appData = appData;
+        });
+
+        cy.intercept("GET", "/hub/application*").as("getApplication");
+        Application.open(true);
+    });
+
+    // Automates TC 532
+    it("Analysis for Gradle JMH application", function () {
+        const application = new Analysis(
+            getRandomApplicationData("JMH Gradle", {
+                sourceData: this.appData["jmh-gradle-example"],
+            }),
+            {
+                source: "Source code + dependencies",
+                effort: 36,
+                target: [],
+            }
+        );
+        application.customRule = ["jmh-gradle-annotation-state-test-rule.yaml"];
+        application.create();
+        applications.push(application);
+        cy.wait("@getApplication");
+        application.analyze();
+        application.verifyAnalysisStatus(AnalysisStatuses.completed);
+        application.verifyEffort(application.effort);
+    });
+
+    after("Clear data", function () {
+        deleteByList(applications);
+    });
+});

--- a/cypress/fixtures/application.json
+++ b/cypress/fixtures/application.json
@@ -71,5 +71,9 @@
     "tackle-testapp-public": {
         "repoType": "Git",
         "sourceRepo": "https://github.com/konveyor/tackle-testapp-public"
+    },
+    "jmh-gradle-example": {
+        "repoType": "Git",
+        "sourceRepo": "https://github.com/melix/jmh-gradle-example"
     }
 }

--- a/cypress/fixtures/yaml/jmh-gradle-annotation-state-test-rule.yaml
+++ b/cypress/fixtures/yaml/jmh-gradle-annotation-state-test-rule.yaml
@@ -1,0 +1,11 @@
+- category: mandatory
+  customVariables: []
+  description: State reference test rule for https://github.com/melix/jmh-gradle-example
+  effort: 1
+  message: |-
+    State reference test rule for https://github.com/melix/jmh-gradle-example
+  ruleID: jmh-gradle-annotation-state-test-rule
+  when:
+    java.referenced:
+      location: ANNOTATION
+      pattern: org.openjdk.jmh.annotations.State


### PR DESCRIPTION
<!-- Add pull request description here -->
Solves [MTA-3176](https://issues.redhat.com/browse/MTA-3176) by automating Polarion TC 532

This TC analyzes a Java application managed with Gradle, using a custom rule that should report a total effort of 36.

I created a new suite because I'll be adding more tests for Gradle in the near future.


![image](https://github.com/user-attachments/assets/aaf2f015-19b2-4091-8420-0c0d2967b7df)

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
