### PR TITLE
[Draft] :sparkles: Adding tests for checking filter&sort abilities in application table

### DIFF
--- a/cypress/e2e/tests/migration/applicationinventory/applications/filter.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/applications/filter.test.ts
@@ -45,6 +45,7 @@ import {
     SEC,
     tags,
     archetypes,
+    analysis,
 } from "../../../../types/constants";
 
 import * as data from "../../../../../utils/data_utils";
@@ -139,6 +140,16 @@ describe(["@tier3"], "Application inventory filter validations", function () {
         exists(applicationsList[0].business);
         clickByText(button, clearAllFilters);
     });
+
+    it("Analysis filter validations",function(){
+        Application.open();
+        getFirstAnalysisColumnValue().then((firstValue) => {
+            cy.log("First Analysis column value: ", firstValue);
+            applySearchFilter(analysis,firstValue);
+            cy.wait(2000);
+            exists(firstValue)
+        });
+     } );
 
     it("Tag filter validations", function () {
         Application.open();
@@ -367,4 +378,18 @@ const filterApplicationsBySubstring = (): void => {
     }
 
     clickByText(button, clearAllFilters);
+};
+
+// this function finds the analysis status of the first application
+const getFirstAnalysisColumnValue = (): Cypress.Chainable<string> => {
+    return cy.get('table').then(($table) => {
+        const analysisColumnIndex = $table.find('th').toArray().findIndex(th => th.innerText.trim() === "Analysis");
+        if (analysisColumnIndex >= 0) {
+            return cy.get(`tbody tr td:nth-child(${analysisColumnIndex + 1})`).first().invoke('text').then((text) => {
+                return text.trim();
+            });
+        } else {
+            return cy.wrap("").then(() => "");
+        }
+    });
 };

--- a/cypress/e2e/tests/migration/applicationinventory/applications/sort.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/applications/sort.test.ts
@@ -24,7 +24,7 @@ import {
     clickOnSortButton,
     deleteByList,
 } from "../../../../../utils/utils";
-import { name, tags, SortType, businessService, SEC } from "../../../../types/constants";
+import { name, tags, SortType, businessService, SEC, analysis } from "../../../../types/constants";
 import * as data from "../../../../../utils/data_utils";
 import { BusinessServices } from "../../../../models/migration/controls/businessservices";
 import { Application } from "../../../../models/migration/applicationinventory/application";
@@ -71,6 +71,24 @@ describe(["@tier3"], "Application inventory sort validations", function () {
 
         // Verify that the application inventory table rows are displayed in descending order
         const afterDescSortList = getTableColumnData(name);
+        verifySortDesc(afterDescSortList, unsortedList);
+    });
+
+    it("Analysis status sort validations", function () {
+        Application.open();
+        // get unsorted list when page loads
+        const unsortedList = getTableColumnData(analysis);
+        // Sort the application inventory by Tag count in ascending order
+        clickOnSortButton(analysis, SortType.ascending);
+        cy.wait(2 * SEC);
+        // Verify that the application inventory table rows are displayed in ascending order
+        const afterAscSortList = getTableColumnData(analysis);
+        verifySortAsc(afterAscSortList, unsortedList);
+        // Sort the application inventory by analysis in descending order
+        clickOnSortButton(analysis, SortType.descending);
+        cy.wait(2000);
+        // Verify that the application inventory table rows are displayed in descending order
+        const afterDescSortList = getTableColumnData(analysis);
         verifySortDesc(afterDescSortList, unsortedList);
     });
 


### PR DESCRIPTION
relates to issue: #1745 in tackle2-ui
Adding ability to test the filter & sort by analysis

Should be merged after: https://github.com/konveyor/tackle2-ui/pull/2100