### PR TITLE
[RFR] updated the invalid questionnaire

### DIFF
--- a/cypress/fixtures/questionnaire_import/invalid-questionnaire-template.yaml
+++ b/cypress/fixtures/questionnaire_import/invalid-questionnaire-template.yaml
@@ -90,7 +90,7 @@ sections:
             risk: green
             selected: false
 thresholds:
-  red: 5
+  red: "five"
   yellow: 10
   unknown: 15
 riskMessages:


### PR DESCRIPTION
Updated the value of red to be a string instead of an integer so it becomes invalid

```
thresholds: 
  red: "five"  <---- here
  yellow: 10 
  unknown: 15
```