### PR TITLE
[JF] [RFR] Fix MTA-437 --- Exports and imports existing questionnaire after updating name in file

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -54,6 +54,7 @@ export default defineConfig({
             require("./cypress/plugins/index.js")(on, config);
             on("file:preprocessor", tagify(config));
             require("cypress-fail-fast/plugin")(on, config);
+            require("cypress-fs/plugins")(on, config);
             return config;
         },
         experimentalMemoryManagement: true,

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -54,7 +54,6 @@ export default defineConfig({
             require("./cypress/plugins/index.js")(on, config);
             on("file:preprocessor", tagify(config));
             require("cypress-fail-fast/plugin")(on, config);
-            require("cypress-fs/plugins")(on, config);
             return config;
         },
         experimentalMemoryManagement: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
                 "cypress": "^13.13.3",
                 "cypress-downloadfile": "^1.2.3",
                 "cypress-fail-fast": "^7.1.0",
+                "cypress-fs": "^0.2.6",
                 "cypress-mochawesome-reporter": "^3.2.2",
                 "cypress-tags": "^1.1.2",
                 "license-check-and-add": "^4.0.5",
@@ -3882,6 +3883,16 @@
             },
             "peerDependencies": {
                 "cypress": ">3.0.0"
+            }
+        },
+        "node_modules/cypress-fs": {
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/cypress-fs/-/cypress-fs-0.2.6.tgz",
+            "integrity": "sha512-sd6IDEP+V9JQ1xbA2SJ6Ao/877yw8HHgqeMRIFvNXdZGHJ8SyBOHEN5jZE9X66M8FSVebXDjnFXnttoMxzfXXQ==",
+            "dev": true,
+            "dependencies": {
+                "cypress": "^13.2.0",
+                "typescript": "^5.0.4"
             }
         },
         "node_modules/cypress-grep": {

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "cypress": "^13.13.3",
         "cypress-downloadfile": "^1.2.3",
         "cypress-fail-fast": "^7.1.0",
+        "cypress-fs": "^0.2.6",
         "cypress-mochawesome-reporter": "^3.2.2",
         "cypress-tags": "^1.1.2",
         "license-check-and-add": "^4.0.5",


### PR DESCRIPTION
added a way to get the latest downloaded questionnaire file instead of giving a static number

[Jenkins Run](https://main-jenkins-csb-migrationqe.apps.ocp-c1.prod.psi.redhat.com/job/mta/job/mta-ui-tests-runner/3976/console)

![image](https://github.com/user-attachments/assets/33f19c95-92bc-4a33-a159-efcd4eb64c3b)
