### PR TITLE
[RFR] [JF] Remove TC that automates MTA-1717

### DIFF
--- a/cypress/e2e/tests/administration/repository/subversion.test.ts
+++ b/cypress/e2e/tests/administration/repository/subversion.test.ts
@@ -20,7 +20,6 @@ import {
     getRandomAnalysisData,
     getRandomApplicationData,
     login,
-    selectLogView,
 } from "../../../../utils/utils";
 import { SubversionConfiguration } from "../../../models/administration/repositories/subversion";
 import { CredentialsSourceControlUsername } from "../../../models/administration/credentials/credentialsSourceControlUsername";
@@ -111,36 +110,6 @@ describe(["@tier2"], "Test secure and insecure svn repository analysis", () => {
                 );
             });
     });
-
-    // Automates customer bug MTA-1717
-    it("Analysis on SVN Repository without trunk folder", function () {
-        subversionConfiguration.enableInsecureSubversionRepositories();
-
-        const application = new Analysis(
-            getRandomApplicationData("svn bookserver app no trunk", {
-                sourceData: this.appData["bookserver-svn-insecure-no-trunk"],
-            }),
-            getRandomAnalysisData(this.analysisData["source_analysis_on_bookserverapp"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.manageCredentials(sourceCredential.name, null);
-        application.analyze();
-        application.verifyAnalysisStatus(AnalysisStatuses.failed);
-        application.openAnalysisDetails();
-
-        cy.intercept("GET", "/hub/tasks/*?merged=1").as("applicationDetails");
-        selectLogView("Merged log view");
-
-        cy.wait("@applicationDetails").then((interception) => {
-            expect(interception.response.body).to.contain(
-                "trunk'' non-existent",
-                "Analysis details don't contains the expected error message"
-            );
-        });
-    });
-
     afterEach("Clear state", function () {
         Analysis.open(true);
     });


### PR DESCRIPTION
removed `Analysis on SVN Repository without trunk folder` TC as it is not relevant any more

This test case was required to test if running analysis on svn repo with trucnk folder missing it should show the relevant error message and the analysis should fail. [see here](https://issues.redhat.com/browse/MTA-1717)

The test failed in the latest run, and a [bug](https://issues.redhat.com/browse/MTA-4324) was opned

But this TC is not required anymore as per discussion with the devs, [see here](https://redhat-internal.slack.com/archives/C048D5SFKSN/p1733409070513449) so it's removed.

**[Jenkins run](https://main-jenkins-csb-migrationqe.apps.ocp-c1.prod.psi.redhat.com/job/mta/job/mta-ui-tests-runner/4110/console)**
