### PR TITLE
Update effort value for binaries  for 7.2.0 branch

### DIFF
--- a/cypress/fixtures/analysis.json
+++ b/cypress/fixtures/analysis.json
@@ -997,7 +997,7 @@
         "target": ["Jakarta EE 9"],
         "binary": ["acmeair-webapp-1.0-SNAPSHOT.war"],
         "appName": "acmeair-webapp-1.0-SNAPSHOT.war",
-        "effort": 78
+        "effort": 79
     },
 
     "uploadbinary_analysis_with_customrule": {
@@ -1106,7 +1106,7 @@
         "binary": ["jee-example-app-1.0.0.ear"],
         "appsName": "jee-example-app-1.0.0.ear",
         "target": ["Quarkus"],
-        "effort": 85,
+        "effort": 112,
         "incidents": [
             {
                 "mandatory": 27,
@@ -1123,7 +1123,7 @@
         "binary": ["camunda-bpm-spring-boot-starter-example-war-2.0.0.war"],
         "appName": "camunda-bpm-spring-boot-starter-example-war-2.0.0.war",
         "target": ["Quarkus"],
-        "effort": 20,
+        "effort": 101,
         "incidents": [
             {
                 "mandatory": 86,
@@ -1140,7 +1140,7 @@
         "binary": ["kafka-clients-sb-sample.jar"],
         "appName": "kafka-clients-sb-sample.jar",
         "target": ["Quarkus"],
-        "effort": 6,
+        "effort": 15,
         "incidents": [
             {
                 "mandatory": 20,


### PR DESCRIPTION
<!-- Add pull request description here -->
The  Analysis for acmeair app upload binary test from upload_binary_analysis.test.ts   is a part of the InterOp suite and is currently failing on the mta_7.2.0 branch.  This PR addresses the failure.

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
