### PR TITLE
[RFR] Update e2e spec glob to only include actual tests

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
     defaultCommandTimeout: 8000,
     e2e: {
         testIsolation: false,
-        specPattern: "cypress/e2e/**/*.{js,jsx,ts,tsx}",
+        specPattern: "cypress/e2e/**/*.test.{js,jsx,ts,tsx}",
         setupNodeEvents(on, config) {
             require("./cypress/plugins/index.js")(on, config);
             on("file:preprocessor", tagify(config));


### PR DESCRIPTION
The e2e spec glob was grabbing all `.ts` files instead of the intended `*.test.ts` files.  This caused problems when cypress attempting to run a lot more tests when a `--spec` argument was not specified.  Now, by default, cypress will only run `*.test.ts` files.

