### PR TITLE
Removed bug MTA-6276 marker as the test is passing

### DIFF
--- a/cypress/e2e/tests/migration/reports-tab/reports.test.ts
+++ b/cypress/e2e/tests/migration/reports-tab/reports.test.ts
@@ -39,7 +39,7 @@ const unknownRiskApps = 2;
 
 let riskType = ["low", "medium", "high", "low", "high", "high"];
 
-describe(["@tier3"], "Bug MTA-2676: Reports tests", () => {
+describe(["@tier3"], "Reports tests", () => {
     before("Login and Create Test Data", function () {
         login();
         AssessmentQuestionnaire.deleteAllQuestionnaires();


### PR DESCRIPTION
the [MTA-6276 bug](https://issues.redhat.com/browse/MTA-2676) is no longer failing, the unassessed option is added to the list of risk types

![image](https://github.com/user-attachments/assets/6d3a7298-e245-4ea2-ada9-32ac07fa389c)
