### PR TITLE
Fix Column selection

### DIFF
--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -1927,8 +1927,9 @@ export function validateCheckBoxIsDisabled(checkBoxText: string, isChecked?: boo
 }
 
 export function getCheckboxSelector(text: string) {
-    text = text.toLowerCase().replace(/\s+/g, "");
-    return `input[aria-labelledby='check-${text}']`;
+    const [first, ...rest] = text.split(" ");
+    text = rest.length ? first.toLowerCase() + rest.join("") : text.toLowerCase();
+    return `input[aria-labelledby='check-${text.replace(/\s+/g, "")}']`;
 }
 
 export function selectColumns(selectedColumns: string[], buttonText: string = save) {


### PR DESCRIPTION
Check if the passed column name has more than one string, if so, then only lower the cases of the first string

**[Jenkins Run](https://jenkins-csb-migrationqe-main.dno.corp.redhat.com/job/mta/job/mta-ui-tests-runner/4501/console)**

![image](https://github.com/user-attachments/assets/cb538c9c-fa17-4f53-b7f4-427ad925eba6)
