### PR TITLE
:bug: [RFR] Fix custom migration target crud test

### DIFF
--- a/cypress/e2e/models/migration/applicationinventory/analysis.ts
+++ b/cypress/e2e/models/migration/applicationinventory/analysis.ts
@@ -19,7 +19,6 @@ import {
     clickByText,
     clickTab,
     clickWithin,
-    clickWithinByText,
     doesExistSelector,
     doesExistText,
     inputText,

--- a/cypress/e2e/models/migration/applicationinventory/analysis.ts
+++ b/cypress/e2e/models/migration/applicationinventory/analysis.ts
@@ -172,11 +172,21 @@ export class Analysis extends Application {
     /**
      * Make sure our language is selected. It may already be selected if language-discovery
      * added it, or if it was added manually.
+     * @param language
+     * @param removePreSelected boolean if true, it will **try** to remove the preselected filters if any
      */
     public static selectLanguage(language: Languages, removePreSelected = false) {
         cy.wait(2 * SEC);
         if (removePreSelected) {
-            clickWithinByText(".pf-v5-c-wizard__main-body", "button", clearAllFilters);
+            cy.get(".pf-v5-c-wizard__main-body")
+                .eq(0)
+                .within(() => {
+                    cy.contains(button, clearAllFilters).should(($btn) => {
+                        if ($btn && $btn.length) {
+                            $btn.trigger("click");
+                        }
+                    });
+                });
         }
 
         cy.get(languageSelectionDropdown).click();

--- a/cypress/e2e/models/migration/migration-waves/migration-wave.ts
+++ b/cypress/e2e/models/migration/migration-waves/migration-wave.ts
@@ -120,7 +120,6 @@ export class MigrationWave {
         cy.contains(button, instance).click();
 
         cy.get(MigrationWaveView.projectSelectToggle).click({ timeout: 20 * SEC });
-        Cypress.$(`button:contains("${project}")`);
         cy.contains(button, project).should(($btn) => {
             expect(
                 $btn,

--- a/package.json
+++ b/package.json
@@ -24,8 +24,8 @@
     "scripts": {
         "e2e:run:local": "cypress run --env tackleUrl=http://localhost:9000",
         "e2e:open:local": "cypress open --e2e --env tackleUrl=http://localhost:9000",
-        "check": "prettier --check './**/*.{ts,js,json}'",
-        "format": "prettier --write './**/*.{ts,js,json}'",
+        "check": "prettier --check './cypress/**/*.{ts,js,json}'",
+        "format": "prettier --write './cypress/**/*.{ts,js,json}'",
         "mergereports": "npx jrm ./cypress/reports/junitreport.xml ./cypress/reports/junit/*.xml"
     },
     "devDependencies": {


### PR DESCRIPTION
<!-- Add pull request description here -->
Resolves https://issues.redhat.com/browse/MIGENG-2074

If the language discovery task takes longer than expected, there will be no language pre-selected when opening the analysis wizard, I updated the method (which is used only here) to click the `clear all filters` button only if present.
<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
