### PR TITLE
:seedling: [RFR] Adapt static report test to baseUrl changes

### DIFF
--- a/cypress/e2e/tests/migration/applicationinventory/analysis/static_report.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/analysis/static_report.test.ts
@@ -78,7 +78,7 @@ describe(["@tier2"], "Prepare Downloaded Report", function () {
     });
 });
 
-describe(["@tier2"], "Test Static Report UI", function () {
+describe(["@tier2"], "Test Static Report UI", { baseUrl: null }, function () {
     const reportData = {
         name: "Adopt Maven Surefire plugin",
         category: "mandatory",

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -69,6 +69,11 @@ declare global {
 }
 
 beforeEach(() => {
+    // Disable for static report test as it need to open local files
+    if (Cypress.spec.name === "static_report.test.ts") {
+        return;
+    }
+
     login();
     // Every test starts by visiting / which should redirect to baseURL/applications
     cy.visit("/");

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -1231,7 +1231,6 @@ export function isTableEmpty(tableSelector: string = commonTable): Cypress.Chain
         .find("div")
         .should("not.have.descendants", "svg.pf-v5-c-spinner")
         .then(($element) => {
-            console.log($element);
             return $element.hasClass("pf-v5-c-empty-state");
         });
 }

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -1229,7 +1229,9 @@ export function isTableEmpty(tableSelector: string = commonTable): Cypress.Chain
     return cy
         .get(tableSelector)
         .find("div")
+        .should("not.have.descendants", "svg.pf-v5-c-spinner")
         .then(($element) => {
+            console.log($element);
             return $element.hasClass("pf-v5-c-empty-state");
         });
 }


### PR DESCRIPTION
<!-- Add pull request description here -->
Resolves [MTA-5004](https://issues.redhat.com/browse/MTA-5004).

`cy.visit` prepends the `baseUrl` to the url passed so now that we have set the `baseUrl` property, the visit to the local report was failing.

In this PR I also add a verification to the `isTableEmpty` method to check that the table has finished loading.

![image](https://github.com/user-attachments/assets/4b088aef-3b2a-4862-89c4-022cf0bd1cc4)

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
