### PR TITLE
:bug: [RFR] Fix business service interlinked test

### DIFF
--- a/cypress/e2e/tests/administration/questionnaires/miscellaneous.test.ts
+++ b/cypress/e2e/tests/administration/questionnaires/miscellaneous.test.ts
@@ -18,7 +18,7 @@ const cloudNativePath = "questionnaire_import/cloud-native.yaml";
 
 const cloudNativeDownloadPath = "cypress/downloads/";
 
-describe(["@tier3"], "Miscellaneous Questinnaire tests", () => {
+describe(["@tier3"], "Miscellaneous Questionnaire tests", () => {
     it("Download YAML template", function () {
         // Polarion TC MTA-397
         AssessmentQuestionnaire.open();

--- a/cypress/e2e/tests/migration/controls/businessservices/interlinked.test.ts
+++ b/cypress/e2e/tests/migration/controls/businessservices/interlinked.test.ts
@@ -25,13 +25,11 @@ import { stakeHoldersTable } from "../../../../views/stakeholders.view";
 
 describe(["@tier3"], "Business service linked to stakeholder", () => {
     beforeEach("Login", function () {
-        // Interceptors for business services
-        cy.intercept("POST", "/hub/business-service*").as("postBusinessService");
-        cy.intercept("GET", "/hub/business-service*").as("getBusinessService");
+        cy.intercept("POST", "/hub/businessservices*").as("postBusinessService");
+        cy.intercept("GET", "/hub/businessservices*").as("getBusinessServices");
 
-        // Interceptors for stakeholders
-        cy.intercept("POST", "/hub/stakeholder*").as("postStakeholder");
-        cy.intercept("GET", "/hub/stakeholder*").as("getStakeholders");
+        cy.intercept("POST", "/hub/stakeholders*").as("postStakeholder");
+        cy.intercept("GET", "/hub/stakeholders*").as("getStakeholders");
     });
 
     it("Stakeholder attach, update and delete dependency on business service", function () {
@@ -39,28 +37,30 @@ describe(["@tier3"], "Business service linked to stakeholder", () => {
         stakeholder.create();
         cy.wait("@postStakeholder");
 
-        const businessservice = new BusinessServices(
+        const businessService = new BusinessServices(
             data.getCompanyName(),
             data.getDescription(),
             stakeholder.name
         );
-        businessservice.create();
-        cy.get("@postBusinessService");
-        exists(businessservice.name);
+        businessService.create();
+        cy.wait("@postBusinessService");
+        exists(businessService.name);
 
         selectItemsPerPage(100);
         cy.get(tdTag)
-            .contains(businessservice.name)
+            .contains(businessService.name)
             .get("td[data-label='Owner']")
             .should("contain", stakeholder.name);
 
-        var updatedStakeholderName = data.getFullName();
+        const updatedStakeholderName = data.getFullName();
         stakeholder.edit({ name: updatedStakeholderName });
         cy.wait("@getStakeholders");
+
         clickByText(navTab, businessServices);
         selectItemsPerPage(100);
+        cy.wait("@getBusinessServices");
         cy.get(tdTag)
-            .contains(businessservice.name)
+            .contains(businessService.name)
             .get("td[data-label='Owner']")
             .should("contain", updatedStakeholderName);
         stakeholder.delete();
@@ -70,11 +70,11 @@ describe(["@tier3"], "Business service linked to stakeholder", () => {
         clickByText(navTab, businessServices);
         selectItemsPerPage(100);
         cy.get(tdTag)
-            .contains(businessservice.name)
+            .contains(businessService.name)
             .get("td[data-label='Owner']")
             .should("not.contain", updatedStakeholderName);
-        businessservice.delete();
-        cy.get("@getBusinessService");
-        notExists(businessservice.name);
+        businessService.delete();
+        cy.wait("@getBusinessServices");
+        notExists(businessService.name);
     });
 });


### PR DESCRIPTION
<!-- Add pull request description here -->
Resolves [MTA-5020](https://issues.redhat.com/browse/MTA-5020)

CI will fail due to the typo fixed on `cypress/e2e/tests/administration/questionnaires/miscellaneous.test.ts` as it has one failing test caused by a product bug

This test was failing when editting the name of a stakeholder assigned to a bussiness service because when going back to the business services page to check if the stakeholder was updated there as well the test was not waiting for the UI to display the updated values.
<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
