### PR TITLE
Update a test's title so cypress-tags doesn't include it by accident

### DIFF
--- a/cypress/e2e/tests/migration/dynamic-report/issues/filter.sorting.pagination.test.ts
+++ b/cypress/e2e/tests/migration/dynamic-report/issues/filter.sorting.pagination.test.ts
@@ -266,7 +266,7 @@ describe(["@tier3"], "Filtering, sorting and pagination in Issues", function () 
             column === "Effort"
                 ? `Bug MTA-4323: Affected applications - sort by ${column}`
                 : `Affected applications - sort by ${column}`;
-        it(title, function () {
+        it(`${title}`, function () {
             Issues.openAffectedApplications(
                 this.analysisData["source_analysis_on_bookserverapp"]["issues"][0]["name"]
             );


### PR DESCRIPTION
Since `cypress-tags` works as a preprocessor, all of the test blocks need to have static tag and title arguments. One test suit has a dynamic title (just a simple ternary is technically dynamic) and was always being included.

Switching the `it()` title to be a template string allows the preprocessor to see it as a string and properly apply the tags from the `define()` block.
