### PR TITLE
[release-0.7] Fix post upgrade tests

### DIFF
--- a/cypress/e2e/models/migration/applicationinventory/analysis.ts
+++ b/cypress/e2e/models/migration/applicationinventory/analysis.ts
@@ -417,6 +417,15 @@ export class Analysis extends Application {
             });
     }
 
+    waitStatusChange(newStatus: string) {
+        cy.get(tdTag, { log: false })
+            .contains(this.name, { log: false })
+            .closest(trTag, { log: false })
+            .within(() => {
+                cy.get(analysisColumn, { timeout: 30 * SEC }).should("contain", newStatus);
+            });
+    }
+
     openReport() {
         sidedrawerTab(this.name, "Reports");
         clickByText(button, "View analysis details");

--- a/cypress/e2e/tests/upgrade/after_upgrade.test.ts
+++ b/cypress/e2e/tests/upgrade/after_upgrade.test.ts
@@ -62,6 +62,7 @@ function processApplication(application: Analysis): void {
     application.extractHTMLReport();
     // Post upgrade: Re-run analysis on an app that was analyzed before upgrade
     application.analyze();
+    application.waitStatusChange("In-progress");
     application.verifyAnalysisStatus("Completed");
     application.downloadReport(ReportTypeSelectors.HTML);
     application.extractHTMLReport();


### PR DESCRIPTION
<!-- Add pull request description here -->
The automation for re-analysis of an already analyzed app after upgrade failed because it takes a few seconds for Analysis status to switch from 'Completed' to 'Not started'. So, I'm adding a new method that waits for analysis status to change.

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->
