### PR TITLE
[RFR] Fix login test by checking the UI's window._env configuration

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
         user: "admin",
         initialPassword: "Passw0rd!",
         pass: "Dog8code",
+        keycloakAdminPassword: "",
         git_user: "",
         git_password: "",
         svn_user: "qe-admin",

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -12,6 +12,7 @@ export default defineConfig({
     video: false,
     env: {
         user: "admin",
+        initialPassword: "Passw0rd!",
         pass: "Dog8code",
         git_user: "",
         git_password: "",
@@ -27,7 +28,7 @@ export default defineConfig({
         jira_atlassian_cloud_project: "Test",
         jira_stage_datacenter_project_id: 12335626,
         rwx_enabled: true,
-        logLevel: "ASSERT",
+        logLevel: "INFO", // VERBOSE, INFO, ASSERT, ERROR
         mtaVersion: "",
         FAIL_FAST_PLUGIN: true,
         FAIL_FAST_ENABLED: false,

--- a/cypress/e2e/tests/login.test.ts
+++ b/cypress/e2e/tests/login.test.ts
@@ -19,7 +19,7 @@ import { selectUserPerspective } from "../../utils/utils";
 import { migration } from "../types/constants";
 
 describe("Log In", () => {
-    it(["@tier1"], "Login to Pathfinder", function () {
+    it(["@ci"], "Open the UI and navigate to Migration/Application Inventory page", function () {
         selectUserPerspective(migration);
         cy.get("h1").should("contain", "Application inventory");
     });

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -43,21 +43,6 @@ if (app && !app.document.head.querySelector("[data-hide-command-log-request]")) 
     app.document.head.appendChild(style);
 }
 
-Cypress.Commands.add("uiEnvironmentConfig", () => {
-    return cy.request("/").then<object>((resp) => {
-        expect(resp.status).to.eq(200);
-
-        cy.log("Looking for _env in UI's index.html");
-        const htmlBody = resp.body;
-        const windowEnv = htmlBody.match(/window\._env\s*=\s*"(.*?)"/);
-        expect(windowEnv, "Find _env in index.html").to.not.be.null;
-
-        const env = JSON.parse(atob(windowEnv[1]));
-        cy.log("window._env: ", JSON.stringify(env));
-        return cy.wrap(env);
-    });
-});
-
 beforeEach(() => {
     // Disable for static report test as it need to open local files
     if (Cypress.spec.name === "static_report.test.ts") {

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -43,27 +43,26 @@ if (app && !app.document.head.querySelector("[data-hide-command-log-request]")) 
     app.document.head.appendChild(style);
 }
 
-beforeEach(() => {
-    // Disable for static report test as it need to open local files
-    if (Cypress.spec.name === "static_report.test.ts") {
-        return;
-    }
-
-    // Look for the window._env data on the application's page, decode it, and push the object
-    // into a alias so other tests can check the UI's _env configuration.
-    cy.request("/").then((resp) => {
-        cy.log("Looking for _env in UI's index.html");
+Cypress.Commands.add("uiEnvironmentConfig", () => {
+    return cy.request("/").then<object>((resp) => {
         expect(resp.status).to.eq(200);
 
+        cy.log("Looking for _env in UI's index.html");
         const htmlBody = resp.body;
         const windowEnv = htmlBody.match(/window\._env\s*=\s*"(.*?)"/);
         expect(windowEnv, "Find _env in index.html").to.not.be.null;
 
         const env = JSON.parse(atob(windowEnv[1]));
         cy.log("window._env: ", JSON.stringify(env));
-
-        cy.wrap(env).as("environmentConfig");
+        return cy.wrap(env);
     });
+});
+
+beforeEach(() => {
+    // Disable for static report test as it need to open local files
+    if (Cypress.spec.name === "static_report.test.ts") {
+        return;
+    }
 
     login();
 

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -43,12 +43,16 @@ if (app && !app.document.head.querySelector("[data-hide-command-log-request]")) 
     app.document.head.appendChild(style);
 }
 
-before(() => {
-    cy.log("Looking for AUTH_REQUIRED");
+beforeEach(() => {
+    // Disable for static report test as it need to open local files
+    if (Cypress.spec.name === "static_report.test.ts") {
+        return;
+    }
 
     // Look for the window._env data on the application's page, decode it, and push the object
     // into a alias so other tests can check the UI's _env configuration.
     cy.request("/").then((resp) => {
+        cy.log("Looking for _env in UI's index.html");
         expect(resp.status).to.eq(200);
 
         const htmlBody = resp.body;
@@ -60,13 +64,6 @@ before(() => {
 
         cy.wrap(env).as("environmentConfig");
     });
-});
-
-beforeEach(() => {
-    // Disable for static report test as it need to open local files
-    if (Cypress.spec.name === "static_report.test.ts") {
-        return;
-    }
 
     login();
 

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -214,7 +214,7 @@ export function login(
     return cy.session(sessionId, () => {
         cy.visit("/", { timeout: 120 * SEC });
 
-        cy.get("@environmentConfig").then((env) => {
+        cy.uiEnvironmentConfig().then((env) => {
             if (env["AUTH_REQUIRED"] === "true") {
                 cy.log("AUTH is enabled, logging in");
 
@@ -222,7 +222,7 @@ export function login(
                 cy.get(loginView.userNameInput, { timeout: 30 * SEC }).should("be.visible");
 
                 // Attempt login
-                inputText(loginView.userNameInput, username, true);
+                inputText(loginView.userNameInput, username);
                 inputText(loginView.userPasswordInput, password);
                 click(loginView.loginButton);
 

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -41,6 +41,7 @@ import {
     JiraType,
     memberCount,
     migration,
+    MIN,
     priority,
     rank,
     save,
@@ -199,52 +200,59 @@ export function cancelForm(): void {
     clickJs(cancelButton);
 }
 
-export function login(username?: string, password?: string, firstLogin = false): Chainable<null> {
+export function login(
+    username: string = Cypress.env("user"),
+    password: string = Cypress.env("pass"),
+    firstLogin = false
+): Chainable<null> {
     /**
      * The sessionId is used to create a new session or to try to recover a previous one
      */
-    const sessionId = (username ?? "login") + (firstLogin ? "FirstLogin" : "");
+    const sessionId = username + (firstLogin ? "FirstLogin" : "");
 
     cy.log(`login a new session or grab the currently logged in session [${sessionId}]`);
     return cy.session(sessionId, () => {
         cy.visit("/", { timeout: 120 * SEC });
-        cy.url().then(($url) => {
-            cy.log($url);
-            if ($url != Application.fullUrl) {
-                const userName = username ?? Cypress.env("user");
-                const userPassword = password ?? Cypress.env("pass");
-                inputText(loginView.userNameInput, userName, true);
-                inputText(loginView.userPasswordInput, userPassword);
+
+        cy.get("@environmentConfig").then((env) => {
+            if (env["AUTH_REQUIRED"] === "true") {
+                cy.log("AUTH is enabled, logging in");
+
+                // Wait up to 30 seconds for the userNameInput field to be visible on the page
+                cy.get(loginView.userNameInput, { timeout: 30 * SEC }).should("be.visible");
+
+                // Attempt login
+                inputText(loginView.userNameInput, username, true);
+                inputText(loginView.userPasswordInput, password);
                 click(loginView.loginButton);
 
-                // Change default password on first login.
+                // If login fails, try the initialPassword
                 cy.get("body").then(($body) => {
-                    let invalidMessageElement = $body.find('span[class*="m-error"]');
-                    if (invalidMessageElement.length > 0) {
-                        const errorText = invalidMessageElement.text().trim();
-                        if (errorText === "Invalid username or password.") {
-                            inputText(loginView.userPasswordInput, "Passw0rd!");
-                            click(loginView.loginButton);
-                            updatePassword();
-                        }
+                    const txt = $body.find("*:contains('Invalid username or password')");
+                    if (txt.length > 0) {
+                        cy.log("Try logging in with the initial password");
+                        inputText(loginView.userPasswordInput, Cypress.env("initialPassword"));
+                        click(loginView.loginButton);
                     }
                 });
-                updatePassword();
-            }
-        });
-        cy.url().should("eq", Application.fullUrl);
-    });
-}
 
-export function updatePassword(): void {
-    // Change password screen which appears only for first login
-    // This is used in PR tester and Jenkins jobs.
-    cy.get("h1", { timeout: 120 * SEC }).then(($a) => {
-        if ($a.text().toString().trim() == "Update password") {
-            inputText(loginView.changePasswordInput, "Dog8code");
-            inputText(loginView.confirmPasswordInput, "Dog8code");
-            click(loginView.submitButton);
-        }
+                // Update the password if it needs to be updated
+                cy.get("body").then(($body) => {
+                    const txt = $body.find("*:contains('You need to change your password')");
+                    if (txt.length > 0) {
+                        cy.log("Attempting to change the password");
+                        inputText(loginView.changePasswordInput, password);
+                        inputText(loginView.confirmPasswordInput, password);
+                        click(loginView.submitButton);
+                    }
+                });
+            } else {
+                cy.log("AUTH is disabled, just look for applications page");
+            }
+
+            // Should be past any auth steps needed, so wait for the url to become "/applications
+            cy.url({ timeout: 1 * MIN }).should("eq", Application.fullUrl);
+        });
     });
 }
 


### PR DESCRIPTION
Before all tests, request the app's index.html and look for the `_env` string to parse.  It is stored as a base-64 encoded JSON object.  The value holds the UI's configuration settings, and most importantly if authorization is enabled.  This _env object can be checked in tests and be able to do different things based on how the UI being tested is configured.

Changes:
  - Adjust the login utils function to be auth aware.  When auth is turned on, handle an initial password that needs to be changed properly.

  - A `before()` block to find, parse and store the `_env` block

  - Since the login test works in AUTH=="false" and AUTH=="true" environments, move the login test to `@ci` so it always runs

  - Adjust the default e2e logging level to INFO so `cy.log()` calls show up by default in the cypress runner UI

  - Added `"baseUrl": "."` to tsconfig.json to resolve a warning message

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a custom command to retrieve and decode the UI environment configuration for use in tests.

- **Bug Fixes**
  - Improved login test flow to handle authentication checks and password changes more reliably.

- **Refactor**
  - Simplified and clarified the login logic for end-to-end tests, integrating password update steps.
  - Updated test case names and tags for better clarity and organization.

- **Chores**
  - Updated environment variable defaults and documentation for test configuration.
  - Minor formatting improvements for test setup scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->