### PR TITLE
[RFR] Fix JF for Task manager - table column management validation

### DIFF
--- a/cypress/e2e/tests/migration/task-manager/manage_columns.test.ts
+++ b/cypress/e2e/tests/migration/task-manager/manage_columns.test.ts
@@ -44,6 +44,7 @@ describe(["@tier3"], "Task manager - table column management validation", functi
 
     it("Select columns to display in the table view - they should be visible", function () {
         // Check the unchecked columns and verify that all columns are visible
+        TaskManager.open();
         selectColumns(columnsToSelect);
         Object.values(TaskManagerTableHeaders).forEach((column) =>
             validateTextPresence(tableHead, column)
@@ -51,17 +52,20 @@ describe(["@tier3"], "Task manager - table column management validation", functi
     });
 
     it("Validate ID checbox in the manage columns window is checked and disabled", function () {
+        TaskManager.open();
         openManageColumns();
         validateCheckBoxIsDisabled(TaskManagerTableHeaders.id, true);
         clickByText(button, save);
     });
 
     it("Validate restoring columns to default", function () {
+        TaskManager.open();
         restoreColumnsToDefault();
         taskManagerDefaultColumns.forEach((column) => validateTextPresence(tableHead, column));
     });
 
     it("Validate cancel button in the manage columns window", function () {
+        TaskManager.open();
         openManageColumns();
         clickByText(button, cancel);
         taskManagerDefaultColumns.forEach((column) => validateTextPresence(tableHead, column));


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/MTA-5521

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of Task Manager column management tests by ensuring the Task Manager page is explicitly opened at the start of each test.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->