### PR TITLE
Adding pr-closed.yaml workflow

### DIFF
--- a/.github/workflows/pr-closed.yaml
+++ b/.github/workflows/pr-closed.yaml
@@ -1,0 +1,17 @@
+name: PR Closed
+
+on:
+    pull_request_target:
+        branches:
+            - main
+        types:
+            - closed
+
+jobs:
+    cherry_pick_job:
+        permissions:
+            pull-requests: write
+            contents: write
+        if: github.event.pull_request.merged == true
+        secrets: inherit
+        uses: konveyor/release-tools/.github/workflows/cherry-pick.yml@main


### PR DESCRIPTION
pr-closed.yaml workflow file exits in most `Konveyor` repos. It is used to create cherry-pick PRs.
For example: for PR in `main` labeled `cherry-pick/release-0.7` - once closed, this workflow will try to create a cherry-pick PR with the changes applied to `release-0.7` branch.
It may fail if there are merge conflicts.