### PR TITLE
[RFR] Fix JF for Filtering, sorting and pagination in Task Manager Page

### DIFF
--- a/.github/workflows/global-ci.yaml
+++ b/.github/workflows/global-ci.yaml
@@ -3,26 +3,20 @@ name: Global CI
 on: ["push", "pull_request"]
 
 jobs:
-  e2e-main:
-    uses: konveyor/ci/.github/workflows/global-ci.yml@main
-    if: "${{github.event.pull_request.base.ref == 'main' }}"
-    with:
-      run_api_tests: false
-      run_ui_tests: true
-      ui_tests_ref: ${{ github.event.number && format('refs/pull/{0}/merge', github.event.number) || '' }}
-      
-  e2e-release-07:
-    uses: konveyor/ci/.github/workflows/global-ci.yml@main
-    if: "${{github.event.pull_request.base.ref == 'release-0.7' }}"
-    with:
-      run_api_tests: false
-      run_ui_tests: true
-      ui_tests_ref: ${{ github.event.number && format('refs/pull/{0}/merge', github.event.number) || '' }}
-      tag: latest # Move this to release-0.7 once a separate branch is cut in operator repo , currently tracks to main.
-      operator_tag: latest #Move this to proper tag once a separate branch is cut in the operator repo, currently tracks to main
+    e2e-main:
+        uses: konveyor/ci/.github/workflows/global-ci.yml@main
+        if: "${{github.event.pull_request.base.ref == 'main' }}"
+        with:
+            run_api_tests: false
+            run_ui_tests: true
+            ui_tests_ref: ${{ github.event.number && format('refs/pull/{0}/merge', github.event.number) || '' }}
 
-
-
-      
-
-
+    e2e-release-07:
+        uses: konveyor/ci/.github/workflows/global-ci.yml@main
+        if: "${{github.event.pull_request.base.ref == 'release-0.7' }}"
+        with:
+            run_api_tests: false
+            run_ui_tests: true
+            ui_tests_ref: ${{ github.event.number && format('refs/pull/{0}/merge', github.event.number) || '' }}
+            tag: release-0.7
+            operator_tag: v0.7.0

--- a/cypress/e2e/tests/migration/task-manager/miscellaneous.test.ts
+++ b/cypress/e2e/tests/migration/task-manager/miscellaneous.test.ts
@@ -19,8 +19,7 @@ import {
     checkSuccessAlert,
     deleteApplicationTableRows,
     deleteCustomResource,
-    getCommandOutput,
-    getNamespace,
+    getNumberOfNonTaskPods,
     getRandomAnalysisData,
     getRandomApplicationData,
     limitPodsByQuota,
@@ -52,17 +51,12 @@ describe(["@tier2"], "Actions in Task Manager Page", function () {
         });
     });
 
-    it("Limit pods to the number of tackle pods + 1", function () {
-        // Polarion TC MTA-553
-        const namespace = getNamespace();
-        const command = `oc get pod --no-headers -n ${namespace} | grep -v task | grep -v Completed | wc -l`;
-        getCommandOutput(command).then((output) => {
-            const podsNumber = Number(output.stdout) + 1;
-            limitPodsByQuota(podsNumber);
-        });
-    });
-
     it("Test Enable and Disable Preemption", function () {
+        // Polarion TC MTA-553
+        // Limit pods to the number of tackle pods + 1
+        getNumberOfNonTaskPods().then((podsNum) => {
+            limitPodsByQuota(podsNum + 1);
+        });
         for (let i = 0; i < 2; i++) {
             bookServerApp = new Analysis(
                 getRandomApplicationData("TaskApp1_", {

--- a/cypress/e2e/tests/migration/task-manager/sorting.filter.pagination.test.ts
+++ b/cypress/e2e/tests/migration/task-manager/sorting.filter.pagination.test.ts
@@ -117,11 +117,13 @@ describe(["@tier3"], "Filtering, sorting and pagination in Task Manager Page", f
         // Filter by ID
         cy.wait("@getTasks")
             .its("response.body")
-            .should("have.length.gte", 2) // Make sure there are at least two items
             .then((responseBody) => {
-                TaskManager.applyFilter(TaskFilter.id, responseBody[0].id.toString());
-                validateNumberPresence(TaskManagerColumns.id, responseBody[0].id);
-                validateTextPresence(TaskManagerColumns.id, responseBody[1].id.toString(), false);
+                // Parse the JSON string into a JavaScript array
+                const parsed =
+                    typeof responseBody === "string" ? JSON.parse(responseBody) : responseBody;
+                TaskManager.applyFilter(TaskFilter.id, parsed[0].id.toString());
+                validateNumberPresence(TaskManagerColumns.id, parsed[0].id);
+                validateTextPresence(TaskManagerColumns.id, parsed[1].id.toString(), false);
                 clearAllFilters();
             });
 

--- a/cypress/e2e/tests/migration/task-manager/sorting.filter.pagination.test.ts
+++ b/cypress/e2e/tests/migration/task-manager/sorting.filter.pagination.test.ts
@@ -20,8 +20,11 @@ import {
     clearAllFilters,
     deleteApplicationTableRows,
     deleteByList,
+    deleteCustomResource,
+    getNumberOfNonTaskPods,
     getRandomAnalysisData,
     getRandomApplicationData,
+    limitPodsByQuota,
     login,
     validateNumberPresence,
     validatePagination,
@@ -30,34 +33,64 @@ import {
 } from "../../../../utils/utils";
 import { Analysis } from "../../../models/migration/applicationinventory/analysis";
 import { TaskManager } from "../../../models/migration/task-manager/task-manager";
-import { TaskFilter, TaskKind, TaskStatus, trTag } from "../../../types/constants";
-import { TaskManagerColumns } from "../../../views/taskmanager.view";
+import { SEC, TaskFilter, TaskKind, TaskStatus, trTag } from "../../../types/constants";
+import { TaskManagerColumns, TaskManagerTableHeaders } from "../../../views/taskmanager.view";
 
 describe(["@tier3"], "Filtering, sorting and pagination in Task Manager Page", function () {
     const applicationsList: Analysis[] = [];
-    const sortByList = ["ID", "Application", "Kind", "Priority", "Created By", "Status"];
 
     before("Login", function () {
-        let bookServerApp: Analysis;
-
         login();
         cy.visit("/");
         deleteApplicationTableRows();
-        cy.fixture("application").then((appData) => {
-            cy.fixture("analysis").then((analysisData) => {
-                for (let i = 0; i < 6; i++) {
-                    bookServerApp = new Analysis(
-                        getRandomApplicationData("TaskFilteringApp_" + i, {
-                            sourceData: appData["bookserver-app"],
-                        }),
-                        getRandomAnalysisData(analysisData["source_analysis_on_bookserverapp"])
-                    );
-                    applicationsList.push(bookServerApp);
-                }
-                applicationsList.forEach((application) => application.create());
-                Analysis.analyzeAll(bookServerApp);
-            });
+    });
+
+    beforeEach("Load data", function () {
+        cy.fixture("application").then(function (appData) {
+            this.appData = appData;
         });
+        cy.fixture("analysis").then(function (analysisData) {
+            this.analysisData = analysisData;
+        });
+    });
+
+    it("Sorting tasks", function () {
+        // Ensure total pod count does not exceed the number of tackle pods.
+        getNumberOfNonTaskPods().then((podsNum) => {
+            limitPodsByQuota(podsNum);
+        });
+
+        let bookServerApp: Analysis;
+        for (let i = 0; i < 6; i++) {
+            bookServerApp = new Analysis(
+                getRandomApplicationData("TaskFilteringApp_" + i, {
+                    sourceData: this.appData["bookserver-app"],
+                }),
+                getRandomAnalysisData(this.analysisData["source_analysis_on_bookserverapp"])
+            );
+            applicationsList.push(bookServerApp);
+        }
+        applicationsList.forEach((application) => application.create());
+        Analysis.analyzeAll(bookServerApp);
+
+        TaskManager.open(100);
+        cy.wait(5 * SEC);
+        const columsToTest = [
+            TaskManagerTableHeaders.id,
+            TaskManagerTableHeaders.application,
+            TaskManagerTableHeaders.kind,
+            TaskManagerTableHeaders.priority,
+            TaskManagerTableHeaders.createdBy,
+            TaskManagerTableHeaders.status,
+        ];
+        columsToTest.forEach((column) => {
+            validateSortBy(column);
+        });
+    });
+
+    // Making sure Resource Quota CR is deleted
+    it("Delete resource quota created in previous test", function () {
+        deleteCustomResource("quota", "task-pods");
     });
 
     it("Filtering tasks", function () {
@@ -136,13 +169,6 @@ describe(["@tier3"], "Filtering, sorting and pagination in Task Manager Page", f
         TaskManager.applyFilter(TaskFilter.applicationName, randomWordGenerator(6));
         cy.get(trTag).should("contain", "No results found");
         clearAllFilters();
-    });
-
-    it("Sorting tasks", function () {
-        TaskManager.open(100);
-        sortByList.forEach((column) => {
-            validateSortBy(column);
-        });
     });
 
     it("Pagination validation", function () {

--- a/cypress/e2e/tests/migration/task-manager/sorting.filter.pagination.test.ts
+++ b/cypress/e2e/tests/migration/task-manager/sorting.filter.pagination.test.ts
@@ -167,7 +167,7 @@ describe(["@tier3"], "Filtering, sorting and pagination in Task Manager Page", f
         clearAllFilters();
     });
 
-    it("Filter by 'Created By'", () => {
+    it("Bug MTA-5753: Filter by 'Created By'", () => {
         TaskManager.open();
         TaskManager.applyFilter(TaskFilter.createdBy, "admin");
         validateTextPresence(TaskManagerColumns.createdBy, "admin");

--- a/cypress/e2e/tests/migration/task-manager/sorting.filter.pagination.test.ts
+++ b/cypress/e2e/tests/migration/task-manager/sorting.filter.pagination.test.ts
@@ -93,11 +93,8 @@ describe(["@tier3"], "Filtering, sorting and pagination in Task Manager Page", f
         deleteCustomResource("quota", "task-pods", true);
     });
 
-    it("Filtering tasks", function () {
+    it("Filtering tasks by Status", function () {
         TaskManager.open();
-        cy.intercept("GET", "/hub/tasks*").as("getTasks");
-
-        // Filter by status
         TaskManager.applyFilter(TaskFilter.status, TaskStatus.pending);
         validateTextPresence(TaskManagerColumns.status, TaskStatus.pending);
         validateTextPresence(TaskManagerColumns.status, TaskStatus.running, false);
@@ -113,8 +110,11 @@ describe(["@tier3"], "Filtering, sorting and pagination in Task Manager Page", f
         validateTextPresence(TaskManagerColumns.status, TaskStatus.running, false);
         validateTextPresence(TaskManagerColumns.status, TaskStatus.pending, false);
         clearAllFilters();
+    });
 
-        // Filter by ID
+    it("Filter by ID", function () {
+        cy.intercept("GET", "/hub/tasks*").as("getTasks");
+        TaskManager.open();
         cy.wait("@getTasks")
             .its("response.body")
             .then((responseBody) => {
@@ -126,8 +126,10 @@ describe(["@tier3"], "Filtering, sorting and pagination in Task Manager Page", f
                 validateTextPresence(TaskManagerColumns.id, parsed[1].id.toString(), false);
                 clearAllFilters();
             });
+    });
 
-        // Filter by Applications
+    it("Filter by Application", () => {
+        TaskManager.open();
         TaskManager.applyFilter(TaskFilter.applicationName, applicationsList[0].name);
         validateTextPresence(TaskManagerColumns.application, applicationsList[0].name);
         validateTextPresence(TaskManagerColumns.application, applicationsList[1].name, false);
@@ -144,8 +146,10 @@ describe(["@tier3"], "Filtering, sorting and pagination in Task Manager Page", f
         validateTextPresence(TaskManagerColumns.kind, TaskKind.languageDiscovery);
         validateTextPresence(TaskManagerColumns.kind, TaskKind.techDiscovery);
         clearAllFilters();
+    });
 
-        // Filter by Kind
+    it("Bug MTA-5739: Filter by Kind", () => {
+        TaskManager.open();
         TaskManager.applyFilter(TaskFilter.kind, TaskKind.analyzer);
         validateTextPresence(TaskManagerColumns.kind, TaskKind.analyzer);
         validateTextPresence(TaskManagerColumns.kind, TaskKind.languageDiscovery, false);
@@ -161,13 +165,17 @@ describe(["@tier3"], "Filtering, sorting and pagination in Task Manager Page", f
         validateTextPresence(TaskManagerColumns.kind, TaskKind.analyzer, false);
         validateTextPresence(TaskManagerColumns.kind, TaskKind.languageDiscovery, false);
         clearAllFilters();
+    });
 
-        // Filter by Created By
+    it("Filter by 'Created By'", () => {
+        TaskManager.open();
         TaskManager.applyFilter(TaskFilter.createdBy, "admin");
         validateTextPresence(TaskManagerColumns.createdBy, "admin");
         clearAllFilters();
+    });
 
-        // Negative test, filtering by not existing data
+    it("Negative test: filtering by not existing data", () => {
+        TaskManager.open();
         TaskManager.applyFilter(TaskFilter.applicationName, randomWordGenerator(6));
         cy.get(trTag).should("contain", "No results found");
         clearAllFilters();

--- a/cypress/e2e/tests/migration/task-manager/sorting.filter.pagination.test.ts
+++ b/cypress/e2e/tests/migration/task-manager/sorting.filter.pagination.test.ts
@@ -54,7 +54,7 @@ describe(["@tier3"], "Filtering, sorting and pagination in Task Manager Page", f
         });
     });
 
-    it("Sorting tasks", function () {
+    it("Bug MTA-5739: Sorting tasks", function () {
         // Ensure total pod count does not exceed the number of tackle pods.
         getNumberOfNonTaskPods().then((podsNum) => {
             limitPodsByQuota(podsNum);

--- a/cypress/e2e/tests/migration/task-manager/sorting.filter.pagination.test.ts
+++ b/cypress/e2e/tests/migration/task-manager/sorting.filter.pagination.test.ts
@@ -90,7 +90,7 @@ describe(["@tier3"], "Filtering, sorting and pagination in Task Manager Page", f
 
     // Making sure Resource Quota CR is deleted
     it("Delete resource quota created in previous test", function () {
-        deleteCustomResource("quota", "task-pods");
+        deleteCustomResource("quota", "task-pods", true);
     });
 
     it("Filtering tasks", function () {

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -1993,6 +1993,16 @@ export function downloadTaskDetails(format = downloadFormatDetails.yaml) {
     });
 }
 
+export function getNumberOfNonTaskPods(): Cypress.Chainable<number> {
+    let podsNumber: number;
+    const namespace = getNamespace();
+    const command = `oc get pod --no-headers -n ${namespace} | grep -v task | grep -v Completed | wc -l`;
+    return getCommandOutput(command).then((output) => {
+        podsNumber = Number(output.stdout);
+        return podsNumber;
+    });
+}
+
 export function limitPodsByQuota(podsNumber: number) {
     const namespace = getNamespace();
     cy.fixture("custom-resource").then((cr) => {

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -2014,9 +2014,16 @@ export function limitPodsByQuota(podsNumber: number) {
     });
 }
 
-export function deleteCustomResource(resourceType: string, resourceName: string) {
+export function deleteCustomResource(
+    resourceType: string,
+    resourceName: string,
+    ignoreNotFound = false
+) {
     const namespace = getNamespace();
-    const command = `oc delete ${resourceType} ${resourceName} -n${namespace}`;
+    let command = `oc delete ${resourceType} ${resourceName} -n${namespace}`;
+    if (ignoreNotFound) {
+        command = `${command} --ignore-not-found=true`;
+    }
     getCommandOutput(command).then((output) => {
         expect(output.code).to.equal(0);
     });


### PR DESCRIPTION
- Cherry-pick #1568

Note: Most of the changes in `.github/workflows/global-ci.yaml` are  code format

Jenkins run: https://jenkins-csb-migrationqe-main.dno.corp.redhat.com/view/MTA/job/mta/job/mta-ui-tests-runner/5528/console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved test structure and data setup for Task Manager sorting, filtering, and pagination tests.
  * Simplified pod count logic in preemption tests by using a new utility function.

* **New Features**
  * Added a utility function to count non-task, non-completed pods for use in tests.

* **Chores**
  * Updated workflow configuration to use explicit release tags and standardized formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->