### PR TITLE
Allow PRs to change the ui_test_tag param for global-ci.yaml

### DIFF
--- a/.github/workflows/global-ci.yaml
+++ b/.github/workflows/global-ci.yaml
@@ -1,22 +1,61 @@
 name: Global CI
 
-on: ["push", "pull_request"]
+on:
+    push:
+        branches:
+            - main
+    pull_request:
+        branches:
+            - main
+            - release-*
+
+env:
+    DEFAULT_UI_TEST_TAGS: "@ci"
 
 jobs:
+    pick-ui-test-tags:
+        runs-on: ubuntu-latest
+        outputs:
+            tags: ${{ steps.extract-tags.outputs.tags }}
+        steps:
+            - name: Extract UI test tags from PR body
+              id: extract-tags
+              env:
+                  PR_BODY: ${{ github.event.pull_request.body }}
+              run: |
+                  if [ "${{ github.event_name }}" = "pull_request" ]; then
+                      if echo "$PR_BODY" | grep -q "ui_test_tags:"; then
+                          TAGS=$(echo "$PR_BODY" | grep "ui_test_tags:" | head -1 | sed 's/^ui_test_tags:[[:space:]]*\(.*\)[[:space:]]*$/\1/')
+                          echo "Found ui_test_tags in PR body: $TAGS"
+                      else
+                          TAGS="${{ env.DEFAULT_UI_TEST_TAGS }}"
+                          echo "No ui_test_tags found in PR body, using default: $TAGS"
+                      fi
+                  else
+                      TAGS="${{ env.DEFAULT_UI_TEST_TAGS }}"
+                      echo "Not a pull request, using default: $TAGS"
+                  fi
+                  echo "tags=$TAGS" >> $GITHUB_OUTPUT
+                  echo "Using ui_test_tags: \`$TAGS\`" >> $GITHUB_STEP_SUMMARY
+
     e2e-main:
+        needs: pick-ui-test-tags
         uses: konveyor/ci/.github/workflows/global-ci.yml@main
         if: "${{github.event.pull_request.base.ref == 'main' }}"
         with:
             run_api_tests: false
             run_ui_tests: true
             ui_tests_ref: ${{ github.event.number && format('refs/pull/{0}/merge', github.event.number) || '' }}
+            ui_test_tags: ${{ needs.pick-ui-test-tags.outputs.tags }}
 
     e2e-release-07:
+        needs: pick-ui-test-tags
         uses: konveyor/ci/.github/workflows/global-ci.yml@main
         if: "${{github.event.pull_request.base.ref == 'release-0.7' }}"
         with:
             run_api_tests: false
             run_ui_tests: true
             ui_tests_ref: ${{ github.event.number && format('refs/pull/{0}/merge', github.event.number) || '' }}
+            ui_test_tags: ${{ needs.pick-ui-test-tags.outputs.tags }}
             tag: release-0.7
             operator_tag: v0.7.0


### PR DESCRIPTION
Enhance Global CI workflow to support dynamic UI test tags extraction from pull request body. Updated triggers for main and release branches, and added a new job to extract and utilize UI test tags, ensuring defaults are applied when none are specified.

In a PR's body, include a line like this to enable tier0 on the global-ci testing for the PR:
```
ui_test_tags: @ci,@tier0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow triggers to run only on specific branches.
  * Added a global environment variable for UI test tags.
  * Introduced a new workflow job to automatically extract UI test tags from pull request descriptions.
  * Modified end-to-end test jobs to use dynamically extracted UI test tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->