### PR TITLE
[RFR] Fix pagination.test.ts

### DIFF
--- a/cypress/e2e/models/migration/archetypes/archetype.ts
+++ b/cypress/e2e/models/migration/archetypes/archetype.ts
@@ -128,10 +128,13 @@ export class Archetype {
 
     create(cancel = false): void {
         Archetype.open();
-        cy.wait(2 * SEC);
         cy.contains("button", "Create new archetype", { timeout: 20000 })
-            .should("be.enabled")
-            .click();
+            .should(($btn) => {
+                // Wait until the button is enabled and visible
+                expect($btn).to.be.visible;
+                expect($btn).not.to.be.disabled;
+            })
+            .click({ force: true });
         if (cancel) {
             cancelForm();
         } else {

--- a/cypress/e2e/tests/migration/archetypes/pagination.test.ts
+++ b/cypress/e2e/tests/migration/archetypes/pagination.test.ts
@@ -17,6 +17,7 @@ limitations under the License.
 
 import {
     checkCurrentPageIs,
+    checkRowCount,
     createMultipleArchetypes,
     deleteAllArchetypes,
     deleteAllRows,
@@ -55,9 +56,7 @@ describe(["@tier3"], "Archetypes pagination validations", function () {
         deleteAllRows();
         // assert that the page is redirected to the previous page, in this case the first page
         checkCurrentPageIs(1);
-        cy.get("td[data-label=Name]").then(($rows) => {
-            cy.wrap($rows.length).should("eq", 10);
-        });
+        checkRowCount(10);
     });
 
     after("Perform test data clean up", function () {

--- a/cypress/e2e/tests/migration/archetypes/pagination.test.ts
+++ b/cypress/e2e/tests/migration/archetypes/pagination.test.ts
@@ -16,6 +16,7 @@ limitations under the License.
 /// <reference types="cypress" />
 
 import {
+    checkCurrentPageIs,
     createMultipleArchetypes,
     deleteAllArchetypes,
     deleteAllRows,
@@ -26,7 +27,6 @@ import {
     validatePagination,
 } from "../../../../utils/utils";
 import { Archetype } from "../../../models/migration/archetypes/archetype";
-import { SEC } from "../../../types/constants";
 let archetypeList: Archetype[] = [];
 
 describe(["@tier3"], "Archetypes pagination validations", function () {
@@ -51,11 +51,10 @@ describe(["@tier3"], "Archetypes pagination validations", function () {
         Archetype.open();
         selectItemsPerPage(10);
         goToLastPage();
+        checkCurrentPageIs(2);
         deleteAllRows();
         // assert that the page is redirected to the previous page, in this case the first page
-        cy.get(".pf-v5-c-pagination__nav-page-select", { timeout: 3 * SEC })
-            .find('input[aria-label="Current page"]')
-            .should("have.value", "1");
+        checkCurrentPageIs(1);
         cy.get("td[data-label=Name]").then(($rows) => {
             cy.wrap($rows.length).should("eq", 10);
         });

--- a/cypress/e2e/tests/migration/archetypes/pagination.test.ts
+++ b/cypress/e2e/tests/migration/archetypes/pagination.test.ts
@@ -26,6 +26,7 @@ import {
     validatePagination,
 } from "../../../../utils/utils";
 import { Archetype } from "../../../models/migration/archetypes/archetype";
+import { SEC } from "../../../types/constants";
 let archetypeList: Archetype[] = [];
 
 describe(["@tier3"], "Archetypes pagination validations", function () {
@@ -51,7 +52,10 @@ describe(["@tier3"], "Archetypes pagination validations", function () {
         selectItemsPerPage(10);
         goToLastPage();
         deleteAllRows();
-        // Verify that page is re-directed to previous page
+        // assert that the page is redirected to the previous page, in this case the first page
+        cy.get(".pf-v5-c-pagination__nav-page-select", { timeout: 3 * SEC })
+            .find('input[aria-label="Current page"]')
+            .should("have.value", "1");
         cy.get("td[data-label=Name]").then(($rows) => {
             cy.wrap($rows.length).should("eq", 10);
         });

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -1218,23 +1218,17 @@ export function isTableEmpty(tableSelector: string = commonTable): Cypress.Chain
 export function deleteAllRows(tableSelector: string = commonTable) {
     // This method is for pages that have delete button inside Kebab menu
     // like Applications and Imports page
-    isTableEmpty().then((empty) => {
-        if (!empty) {
-            cy.get(tableSelector)
-                .find(trTag)
-                .then(($rows) => {
-                    for (let i = 0; i < $rows.length - 1; i++) {
-                        cy.get(sideKebabMenu, { timeout: 10000 }).first().click();
-                        cy.get("ul[role=menu] > li").contains("Delete").click();
-                        cy.get(confirmButton).click();
-                        cy.wait(5000);
-                        isTableEmpty().then((empty) => {
-                            if (empty) return;
-                        });
-                    }
-                });
-        }
-    });
+
+    cy.get(tableSelector)
+        .find(trTag)
+        .then(($rows) => {
+            for (let i = 0; i < $rows.length - 1; i++) {
+                cy.get(sideKebabMenu, { timeout: 10000 }).first().click();
+                cy.get("ul[role=menu] > li").contains("Delete").click();
+                cy.get(confirmButton).click();
+                cy.wait(5000);
+            }
+        });
 }
 
 export function deleteAllImports(tableSelector: string = commonTable) {

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -948,9 +948,9 @@ export function createMultipleArchetypes(number, tags?: Tag[]): Archetype[] {
         let archetype: Archetype;
         if (tags) archetype = new Archetype(data.getRandomWord(6), [tags[i].name], [tags[i].name]);
         else archetype = new Archetype(data.getRandomWord(6), [randomTagName], [randomTagName]);
-        cy.wait(2 * SEC);
         archetype.create();
-        cy.wait(2 * SEC);
+        // asserts the creation success popup is visible and then closes it.
+        assertSuccessPopupAndClose();
         archetypesList.push(archetype);
     }
     return archetypesList;
@@ -1227,17 +1227,26 @@ export function deleteAllRows(tableSelector: string = commonTable) {
                             .click();
                         cy.get("ul[role=menu] > li").contains("Delete").click();
                         cy.get(confirmButton).click();
-                        // asserts the deletion popup is visible and then closes it.
-                        cy.get("ul.pf-v5-c-alert-group.pf-m-toast li .pf-v5-c-alert.pf-m-success", {
-                            timeout: 3 * SEC,
-                        })
-                            .should("be.visible")
-                            .within(() => {
-                                cy.get('button[aria-label^="Close"]').click();
-                            });
+                        // asserts the deletion success popup is visible and then closes it.
+                        assertSuccessPopupAndClose();
                     }
                 });
         }
+    });
+}
+
+export function assertSuccessPopupAndClose() {
+    cy.get("ul.pf-v5-c-alert-group.pf-m-toast li .pf-v5-c-alert.pf-m-success", {
+        timeout: 3 * SEC,
+    })
+        .should("be.visible")
+        .within(() => {
+            cy.get('button[aria-label^="Close"]').click();
+        });   
+}
+export function checkRowCount(expectedCount: number) {
+    cy.get("td[data-label=Name]").then(($rows) => {
+        cy.wrap($rows.length).should("eq", expectedCount);
     });
 }
 
@@ -1519,6 +1528,7 @@ export function autoPageChangeValidations(
 
 export function goToLastPage(): void {
     cy.get(lastPageButton, { timeout: 10 * SEC })
+        .should("not.be.disabled", { timeout: 10 * SEC })
         .eq(1)
         .then(($button) => {
             if (!$button.hasClass(".pf-m-disabled")) {

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -949,7 +949,6 @@ export function createMultipleArchetypes(number, tags?: Tag[]): Archetype[] {
         if (tags) archetype = new Archetype(data.getRandomWord(6), [tags[i].name], [tags[i].name]);
         else archetype = new Archetype(data.getRandomWord(6), [randomTagName], [randomTagName]);
         archetype.create();
-        // asserts the creation success popup is visible and then closes it.
         assertSuccessPopupAndClose();
         archetypesList.push(archetype);
     }
@@ -1227,7 +1226,6 @@ export function deleteAllRows(tableSelector: string = commonTable) {
                             .click();
                         cy.get("ul[role=menu] > li").contains("Delete").click();
                         cy.get(confirmButton).click();
-                        // asserts the deletion success popup is visible and then closes it.
                         assertSuccessPopupAndClose();
                     }
                 });
@@ -1236,7 +1234,7 @@ export function deleteAllRows(tableSelector: string = commonTable) {
 }
 
 export function assertSuccessPopupAndClose() {
-    cy.get("ul.pf-v5-c-alert-group.pf-m-toast li .pf-v5-c-alert.pf-m-success", {
+    cy.get(successAlertMessage, {
         timeout: 3 * SEC,
     })
         .should("be.visible")

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -1222,7 +1222,9 @@ export function deleteAllRows(tableSelector: string = commonTable) {
                 .find(trTag)
                 .then(($rows) => {
                     for (let i = 0; i < $rows.length - 1; i++) {
-                        cy.get(sideKebabMenu, { timeout: 10000 }).first().click();
+                        cy.get(sideKebabMenu, { timeout: 10 * SEC })
+                            .first()
+                            .click();
                         cy.get("ul[role=menu] > li").contains("Delete").click();
                         cy.get(confirmButton).click();
                         // asserts the deletion popup is visible and then closes it.
@@ -1523,6 +1525,12 @@ export function goToLastPage(): void {
                 $button.click();
             }
         });
+}
+
+export function checkCurrentPageIs(pageNumber: number) {
+    cy.get(".pf-v5-c-pagination__nav-page-select", { timeout: 10 * SEC })
+        .find('input[aria-label="Current page"]')
+        .should("have.value", pageNumber.toString());
 }
 
 export function validateValue(selector, value: string): void {

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -1216,19 +1216,27 @@ export function isTableEmpty(tableSelector: string = commonTable): Cypress.Chain
 }
 
 export function deleteAllRows(tableSelector: string = commonTable) {
-    // This method is for pages that have delete button inside Kebab menu
-    // like Applications and Imports page
-
-    cy.get(tableSelector)
-        .find(trTag)
-        .then(($rows) => {
-            for (let i = 0; i < $rows.length - 1; i++) {
-                cy.get(sideKebabMenu, { timeout: 10000 }).first().click();
-                cy.get("ul[role=menu] > li").contains("Delete").click();
-                cy.get(confirmButton).click();
-                cy.wait(5000);
-            }
-        });
+    isTableEmpty().then((empty) => {
+        if (!empty) {
+            cy.get(tableSelector)
+                .find(trTag)
+                .then(($rows) => {
+                    for (let i = 0; i < $rows.length - 1; i++) {
+                        cy.get(sideKebabMenu, { timeout: 10000 }).first().click();
+                        cy.get("ul[role=menu] > li").contains("Delete").click();
+                        cy.get(confirmButton).click();
+                        // asserts the deletion popup is visible and then closes it.
+                        cy.get("ul.pf-v5-c-alert-group.pf-m-toast li .pf-v5-c-alert.pf-m-success", {
+                            timeout: 3 * SEC,
+                        })
+                            .should("be.visible")
+                            .within(() => {
+                                cy.get('button[aria-label^="Close"]').click();
+                            });
+                    }
+                });
+        }
+    });
 }
 
 export function deleteAllImports(tableSelector: string = commonTable) {

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -1242,7 +1242,7 @@ export function assertSuccessPopupAndClose() {
         .should("be.visible")
         .within(() => {
             cy.get('button[aria-label^="Close"]').click();
-        });   
+        });
 }
 export function checkRowCount(expectedCount: number) {
     cy.get("td[data-label=Name]").then(($rows) => {


### PR DESCRIPTION
## Summary

- Refactor deleteAllRows function to remove unnecessary isTableEmpty check. Streamlined the deletion process for table rows by directly iterating through the rows. because the table relaods before the inner `isEmpty()` is called, so for the code the table is not yet empty so it deletes also the first page which causes the test to fail
- Replace `cy.wait()` with actual way of asserting the row is deleted.
- Added function to assert the UI is redirected to the previouse page.

## Test Run

- [mta 8.0.0-29](https://jenkins-csb-migrationqe-main.dno.corp.redhat.com/job/mta/job/mta-ui-tests-runner/5694/console) 
- [mta 8.0.0-29 second run](https://jenkins-csb-migrationqe-main.dno.corp.redhat.com/job/mta/job/mta-ui-tests-runner/5696/console)
- [Test run after requested changes](https://jenkins-csb-migrationqe-main.dno.corp.redhat.com/job/mta/job/mta-ui-tests-runner/5697/console)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Deletion flow now relies on visible success toasts instead of fixed waits for more reliable behavior.
* **Bug Fixes**
  * Deleting last items on a page correctly returns the view to the previous/first page to avoid stale pagination.
* **Tests**
  * End-to-end tests updated to assert success feedback and confirm correct pagination transitions.
* **New Features**
  * Added UI checks for current page and row count to validate pagination state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->