### PR TITLE
Fix download import template test

### DIFF
--- a/cypress/e2e/tests/migration/applicationinventory/manageimports/csv.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/manageimports/csv.test.ts
@@ -16,7 +16,6 @@ limitations under the License.
 /// <reference types="cypress" />
 
 import { cleanupDownloads, login, openManageImportsPage } from "../../../../../utils/utils";
-import { Application } from "../../../../models/migration/applicationinventory/application";
 import { kebabMenuItem } from "../../../../views/applicationinventory.view";
 import { manageImportsActionsButton } from "../../../../views/common.view";
 
@@ -24,12 +23,11 @@ describe(["@tier3"], "Manage imports tests", function () {
     before("Login", function () {
         login();
         cy.visit("/");
-        Application.open();
-        openManageImportsPage();
     });
 
     it("Download CSV template", function () {
-        cy.get(manageImportsActionsButton).eq(0).click({ force: true });
+        openManageImportsPage();
+        cy.get(manageImportsActionsButton).click();
         cy.get(kebabMenuItem).contains("Download CSV template").click();
         cy.readFile("cypress/downloads/template_application_import.csv").should(
             "contain",


### PR DESCRIPTION
<!-- Add pull request description here -->

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Adjusted test setup to remove automatic application opening; navigation to the Manage Imports page now occurs within the specific test.
  * Updated the download-CSV-template test to use the revised navigation flow while keeping assertions and expected downloaded content unchanged. No user-facing changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->