### PR TITLE
[RFR][TA] MTA-707 - Refactor source analysis tests to use default credentials

### DIFF
--- a/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
@@ -129,290 +129,290 @@ describe(["@tier2"], "Source Analysis", () => {
         }
     );
 
-    // it("Source + dependencies analysis on daytrader app", function () {
-    //     // Automate bug https://issues.redhat.com/browse/TACKLE-721
-    //     const application = new Analysis(
-    //         getRandomApplicationData("dayTraderApp_Source+dependencies", {
-    //             sourceData: this.appData["daytrader-app"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["source+dep_analysis_on_daytrader-app"])
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.analyze();
-    //     // Daytrader app take more than 20 min to analyze
-    //     application.verifyAnalysisStatus("Completed", 30 * MIN);
-    //     application.verifyEffort(
-    //         this.analysisData["source+dep_analysis_on_daytrader-app"]["effort"]
-    //     );
-    //     application.validateIssues(
-    //         this.analysisData["source+dep_analysis_on_daytrader-app"]["issues"]
-    //     );
-    //     // Automate bug https://issues.redhat.com/browse/MTA-2006
-    //     this.analysisData["source+dep_analysis_on_daytrader-app"]["issues"].forEach(
-    //         (currentIssue: AppIssue) => {
-    //             application.validateAffected(currentIssue);
-    //         }
-    //     );
-    // });
+    it("Source + dependencies analysis on daytrader app", function () {
+        // Automate bug https://issues.redhat.com/browse/TACKLE-721
+        const application = new Analysis(
+            getRandomApplicationData("dayTraderApp_Source+dependencies", {
+                sourceData: this.appData["daytrader-app"],
+            }),
+            getRandomAnalysisData(this.analysisData["source+dep_analysis_on_daytrader-app"])
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.analyze();
+        // Daytrader app take more than 20 min to analyze
+        application.verifyAnalysisStatus("Completed", 30 * MIN);
+        application.verifyEffort(
+            this.analysisData["source+dep_analysis_on_daytrader-app"]["effort"]
+        );
+        application.validateIssues(
+            this.analysisData["source+dep_analysis_on_daytrader-app"]["issues"]
+        );
+        // Automate bug https://issues.redhat.com/browse/MTA-2006
+        this.analysisData["source+dep_analysis_on_daytrader-app"]["issues"].forEach(
+            (currentIssue: AppIssue) => {
+                application.validateAffected(currentIssue);
+            }
+        );
+    });
 
-    // it("Analysis on daytrader app with maven credentials", function () {
-    //     // Automate bug https://issues.redhat.com/browse/TACKLE-751
-    //     const application = new Analysis(
-    //         getRandomApplicationData("dayTraderApp_MavenCreds", {
-    //             sourceData: this.appData["daytrader-app"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["source+dep_analysis_on_daytrader-app"])
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.manageCredentials(null, mavenCredential.name);
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed");
-    // });
+    it("Analysis on daytrader app with maven credentials", function () {
+        // Automate bug https://issues.redhat.com/browse/TACKLE-751
+        const application = new Analysis(
+            getRandomApplicationData("dayTraderApp_MavenCreds", {
+                sourceData: this.appData["daytrader-app"],
+            }),
+            getRandomAnalysisData(this.analysisData["source+dep_analysis_on_daytrader-app"])
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.manageCredentials(null, mavenCredential.name);
+        application.analyze();
+        application.verifyAnalysisStatus("Completed");
+    });
 
-    // it(["@tier1"], "Source Analysis on tackle testapp", function () {
-    //     // For tackle test app source credentials are required.
-    //     const application = new Analysis(
-    //         getRandomApplicationData("tackleTestApp_Source", {
-    //             sourceData: this.appData["tackle-testapp-git"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.manageCredentials(sourceCredential.name, null);
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed", 30 * MIN);
-    // });
+    it(["@tier1"], "Source Analysis on tackle testapp", function () {
+        // For tackle test app source credentials are required.
+        const application = new Analysis(
+            getRandomApplicationData("tackleTestApp_Source", {
+                sourceData: this.appData["tackle-testapp-git"],
+            }),
+            getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.manageCredentials(sourceCredential.name, null);
+        application.analyze();
+        application.verifyAnalysisStatus("Completed", 30 * MIN);
+    });
 
-    // it("Analysis on tackle test app with ssh credentials", function () {
-    //     // Automate bug https://issues.redhat.com/browse/TACKLE-707
-    //     const scCredsKey = new CredentialsSourceControlKey(
-    //         data.getRandomCredentialsData(
-    //             CredentialType.sourceControl,
-    //             UserCredentials.sourcePrivateKey
-    //         )
-    //     );
-    //     scCredsKey.create();
-    //     const application = new Analysis(
-    //         getRandomApplicationData("tackleTestApp_sshCreds", {
-    //             sourceData: this.appData["tackle-testapp-ssh"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.manageCredentials(scCredsKey.name, null);
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed");
-    // });
+    it("Analysis on tackle test app with ssh credentials", function () {
+        // Automate bug https://issues.redhat.com/browse/TACKLE-707
+        const scCredsKey = new CredentialsSourceControlKey(
+            data.getRandomCredentialsData(
+                CredentialType.sourceControl,
+                UserCredentials.sourcePrivateKey
+            )
+        );
+        scCredsKey.create();
+        const application = new Analysis(
+            getRandomApplicationData("tackleTestApp_sshCreds", {
+                sourceData: this.appData["tackle-testapp-ssh"],
+            }),
+            getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.manageCredentials(scCredsKey.name, null);
+        application.analyze();
+        application.verifyAnalysisStatus("Completed");
+    });
 
-    // it("Analysis for known Open Source libraries on tackleTest app", function () {
-    //     // Source code analysis require both source and maven credentials
-    //     const application = new Analysis(
-    //         getRandomApplicationData("tackleTestApp_Source+knownLibraries", {
-    //             sourceData: this.appData["tackle-testapp-git"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["analysis_for_openSourceLibraries"])
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.manageCredentials(sourceCredential.name, mavenCredential.name);
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed", 30 * MIN);
-    // });
+    it("Analysis for known Open Source libraries on tackleTest app", function () {
+        // Source code analysis require both source and maven credentials
+        const application = new Analysis(
+            getRandomApplicationData("tackleTestApp_Source+knownLibraries", {
+                sourceData: this.appData["tackle-testapp-git"],
+            }),
+            getRandomAnalysisData(this.analysisData["analysis_for_openSourceLibraries"])
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.manageCredentials(sourceCredential.name, mavenCredential.name);
+        application.analyze();
+        application.verifyAnalysisStatus("Completed", 30 * MIN);
+    });
 
-    // it("Automated tagging using Source Analysis on tackle testapp", function () {
-    //     // Automates Polarion MTA-208
-    //     const application = new Analysis(
-    //         getRandomApplicationData("tackleTestApp_Source_autoTagging", {
-    //             sourceData: this.appData["tackle-testapp-git"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.manageCredentials(sourceCredential.name, null);
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed");
-    //     application.applicationDetailsTab("Tags");
-    //     application.tagAndCategoryExists(
-    //         this.analysisData["analysis_for_enableTagging"]["techTags"]
-    //     );
-    //     application.closeApplicationDetails();
-    // });
+    it("Automated tagging using Source Analysis on tackle testapp", function () {
+        // Automates Polarion MTA-208
+        const application = new Analysis(
+            getRandomApplicationData("tackleTestApp_Source_autoTagging", {
+                sourceData: this.appData["tackle-testapp-git"],
+            }),
+            getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.manageCredentials(sourceCredential.name, null);
+        application.analyze();
+        application.verifyAnalysisStatus("Completed");
+        application.applicationDetailsTab("Tags");
+        application.tagAndCategoryExists(
+            this.analysisData["analysis_for_enableTagging"]["techTags"]
+        );
+        application.closeApplicationDetails();
+    });
 
-    // it("Bug MTA-3418: Disable Automated tagging using Source Analysis on bookServer app", function () {
-    //     // Automates Polarion MTA-307
-    //     const application = new Analysis(
-    //         getRandomApplicationData("bookserverApp_Disable_autoTagging", {
-    //             sourceData: this.appData["bookserver-app"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["analysis_for_disableTagging"])
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed");
-    //     application.verifyEffort(this.analysisData["analysis_for_disableTagging"]["effort"]);
-    //     application.applicationDetailsTab("Tags");
-    //     cy.get("h2", { timeout: 5 * SEC }).should("contain", "No tags available");
-    // });
+    it("Bug MTA-3418: Disable Automated tagging using Source Analysis on bookServer app", function () {
+        // Automates Polarion MTA-307
+        const application = new Analysis(
+            getRandomApplicationData("bookserverApp_Disable_autoTagging", {
+                sourceData: this.appData["bookserver-app"],
+            }),
+            getRandomAnalysisData(this.analysisData["analysis_for_disableTagging"])
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.analyze();
+        application.verifyAnalysisStatus("Completed");
+        application.verifyEffort(this.analysisData["analysis_for_disableTagging"]["effort"]);
+        application.applicationDetailsTab("Tags");
+        cy.get("h2", { timeout: 5 * SEC }).should("contain", "No tags available");
+    });
 
-    // it("Analysis for Konveyor example1 application", function () {
-    //     // Automates https://github.com/konveyor/example-applications/tree/main/example-1
-    //     const application = new Analysis(
-    //         getRandomApplicationData("Example 1", {
-    //             sourceData: this.appData["konveyor-exampleapp"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["analysis_on_example-1-app"])
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed");
-    //     // Polarion TC 406
-    //     application.verifyEffort(this.analysisData["analysis_on_example-1-app"]["effort"]);
-    // });
+    it("Analysis for Konveyor example1 application", function () {
+        // Automates https://github.com/konveyor/example-applications/tree/main/example-1
+        const application = new Analysis(
+            getRandomApplicationData("Example 1", {
+                sourceData: this.appData["konveyor-exampleapp"],
+            }),
+            getRandomAnalysisData(this.analysisData["analysis_on_example-1-app"])
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.analyze();
+        application.verifyAnalysisStatus("Completed");
+        // Polarion TC 406
+        application.verifyEffort(this.analysisData["analysis_on_example-1-app"]["effort"]);
+    });
 
-    // it("JWS6 target Source + deps analysis on tackletest app", function () {
-    //     // Source code analysis require both source and maven credentials
-    //     const application = new Analysis(
-    //         getRandomApplicationData("tackleTestApp_Source+dependencies_jws6", {
-    //             sourceData: this.appData["tackle-testapp-git"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["jws6_source+dep_analysis_on_tackletestapp"])
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.manageCredentials(sourceCredential.name, mavenCredential.name);
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed");
-    // });
+    it("JWS6 target Source + deps analysis on tackletest app", function () {
+        // Source code analysis require both source and maven credentials
+        const application = new Analysis(
+            getRandomApplicationData("tackleTestApp_Source+dependencies_jws6", {
+                sourceData: this.appData["tackle-testapp-git"],
+            }),
+            getRandomAnalysisData(this.analysisData["jws6_source+dep_analysis_on_tackletestapp"])
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.manageCredentials(sourceCredential.name, mavenCredential.name);
+        application.analyze();
+        application.verifyAnalysisStatus("Completed");
+    });
 
-    // it("Bug MTA-4412: Bug MTA-5212  Openjdk17 Source + dependencies analysis on tackletest app", function () {
-    //     const application = new Analysis(
-    //         getRandomApplicationData("tackleTestApp_Source+dependencies_openjdk17", {
-    //             sourceData: this.appData["tackle-testapp-git"],
-    //         }),
-    //         getRandomAnalysisData(
-    //             this.analysisData["openJDK17_source+dep_analysis_on_tackletestapp"]
-    //         )
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.manageCredentials(sourceCredential.name, mavenCredential.name);
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed");
-    //     application.verifyEffort(
-    //         this.analysisData["openJDK17_source+dep_analysis_on_tackletestapp"]["effort"]
-    //     );
-    // });
+    it("Bug MTA-4412: Bug MTA-5212  Openjdk17 Source + dependencies analysis on tackletest app", function () {
+        const application = new Analysis(
+            getRandomApplicationData("tackleTestApp_Source+dependencies_openjdk17", {
+                sourceData: this.appData["tackle-testapp-git"],
+            }),
+            getRandomAnalysisData(
+                this.analysisData["openJDK17_source+dep_analysis_on_tackletestapp"]
+            )
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.manageCredentials(sourceCredential.name, mavenCredential.name);
+        application.analyze();
+        application.verifyAnalysisStatus("Completed");
+        application.verifyEffort(
+            this.analysisData["openJDK17_source+dep_analysis_on_tackletestapp"]["effort"]
+        );
+    });
 
-    // it("OpenJDK21 Source + dependencies analysis on daytrader app", function () {
-    //     const application = new Analysis(
-    //         getRandomApplicationData("dayTraderApp_Source+dependencies_openjdk21", {
-    //             sourceData: this.appData["daytrader-app"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["openJDK21_source+dep_analysis_on_dayTrader"])
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed", 30 * MIN);
-    //     application.verifyEffort(
-    //         this.analysisData["openJDK21_source+dep_analysis_on_dayTrader"]["effort"]
-    //     );
-    // });
+    it("OpenJDK21 Source + dependencies analysis on daytrader app", function () {
+        const application = new Analysis(
+            getRandomApplicationData("dayTraderApp_Source+dependencies_openjdk21", {
+                sourceData: this.appData["daytrader-app"],
+            }),
+            getRandomAnalysisData(this.analysisData["openJDK21_source+dep_analysis_on_dayTrader"])
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.analyze();
+        application.verifyAnalysisStatus("Completed", 30 * MIN);
+        application.verifyEffort(
+            this.analysisData["openJDK21_source+dep_analysis_on_dayTrader"]["effort"]
+        );
+    });
 
-    // // Automates customer bug MTA-1785
-    // it("JDK<11 Source + dependencies analysis on tackle app public", function () {
-    //     const application = new Analysis(
-    //         getRandomApplicationData("tackle testapp public jdk 9", {
-    //             sourceData: this.appData["tackle-testapp-public-jdk9"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["jdk9_source_dep_analysis_on_tackletestapp"])
-    //     );
-    //     application.create();
-    //     application.manageCredentials(null, mavenCredential.name);
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.analyze();
-    //     application.verifyAnalysisStatus(AnalysisStatuses.completed);
-    // });
+    // Automates customer bug MTA-1785
+    it("JDK<11 Source + dependencies analysis on tackle app public", function () {
+        const application = new Analysis(
+            getRandomApplicationData("tackle testapp public jdk 9", {
+                sourceData: this.appData["tackle-testapp-public-jdk9"],
+            }),
+            getRandomAnalysisData(this.analysisData["jdk9_source_dep_analysis_on_tackletestapp"])
+        );
+        application.create();
+        application.manageCredentials(null, mavenCredential.name);
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.analyze();
+        application.verifyAnalysisStatus(AnalysisStatuses.completed);
+    });
 
-    // // Automates bug MTA-3422
-    // it("4 targets source analysis on tackle app public", function () {
-    //     const application = new Analysis(
-    //         getRandomApplicationData("tackle-public-4-targets", {
-    //             sourceData: this.appData["tackle-testapp-public"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["tackle-testapp-public-4-targets"])
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed");
-    //     application.verifyEffort(this.analysisData["tackle-testapp-public-4-targets"]["effort"]);
-    // });
+    // Automates bug MTA-3422
+    it("4 targets source analysis on tackle app public", function () {
+        const application = new Analysis(
+            getRandomApplicationData("tackle-public-4-targets", {
+                sourceData: this.appData["tackle-testapp-public"],
+            }),
+            getRandomAnalysisData(this.analysisData["tackle-testapp-public-4-targets"])
+        );
+        application.create();
+        applicationsList.push(application);
+        application.analyze();
+        application.verifyAnalysisStatus("Completed");
+        application.verifyEffort(this.analysisData["tackle-testapp-public-4-targets"]["effort"]);
+    });
 
-    // // Automates customer bug MTA-2973
-    // it("Source analysis on tackle app public with custom rule", function () {
-    //     for (let i = 0; i < 2; i++) {
-    //         const application = new Analysis(
-    //             getRandomApplicationData("tackle-public-customRule", {
-    //                 sourceData: this.appData["tackle-testapp-public"],
-    //             }),
-    //             getRandomAnalysisData(this.analysisData["tackle-testapp-public-customRule"])
-    //         );
-    //         applicationsList.push(application);
-    //     }
+    // Automates customer bug MTA-2973
+    it("Source analysis on tackle app public with custom rule", function () {
+        for (let i = 0; i < 2; i++) {
+            const application = new Analysis(
+                getRandomApplicationData("tackle-public-customRule", {
+                    sourceData: this.appData["tackle-testapp-public"],
+                }),
+                getRandomAnalysisData(this.analysisData["tackle-testapp-public-customRule"])
+            );
+            applicationsList.push(application);
+        }
 
-    //     // Analyze an application
-    //     const analyzeApplication = (application, credentials) => {
-    //         application.create();
-    //         if (credentials) application.manageCredentials(null, credentials.name);
-    //         application.analyze();
-    //         application.verifyAnalysisStatus("Completed");
-    //         application.validateIssues(
-    //             this.analysisData["tackle-testapp-public-customRule"]["issues"]
-    //         );
-    //     };
+        // Analyze an application
+        const analyzeApplication = (application, credentials) => {
+            application.create();
+            if (credentials) application.manageCredentials(null, credentials.name);
+            application.analyze();
+            application.verifyAnalysisStatus("Completed");
+            application.validateIssues(
+                this.analysisData["tackle-testapp-public-customRule"]["issues"]
+            );
+        };
 
-    //     // Analyze application with Maven credentials
-    //     analyzeApplication(applicationsList[0], mavenCredential);
+        // Analyze application with Maven credentials
+        analyzeApplication(applicationsList[0], mavenCredential);
 
-    //     // Analyze application without Maven credentials
-    //     analyzeApplication(applicationsList[1], null);
-    // });
+        // Analyze application without Maven credentials
+        analyzeApplication(applicationsList[1], null);
+    });
 
-    // it("Bug MTA-3701: Source analysis on tackle app with hash in Password", function () {
-    //     const application = new Analysis(
-    //         getRandomApplicationData("tackleTestApp_Source", {
-    //             sourceData: this.appData["tackle-testapp-git"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["tackleTestApp_Source"])
-    //     );
+    it("Bug MTA-3701: Source analysis on tackle app with hash in Password", function () {
+        const application = new Analysis(
+            getRandomApplicationData("tackleTestApp_Source", {
+                sourceData: this.appData["tackle-testapp-git"],
+            }),
+            getRandomAnalysisData(this.analysisData["tackleTestApp_Source"])
+        );
 
-    //     // Analysis application with source credential created with hash
-    //     application.create();
-    //     application.manageCredentials(sourceCredentialWithHash.name);
-    //     applicationsList.push(application);
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed");
-    // });
+        // Analysis application with source credential created with hash
+        application.create();
+        application.manageCredentials(sourceCredentialWithHash.name);
+        applicationsList.push(application);
+        application.analyze();
+        application.verifyAnalysisStatus("Completed");
+    });
 
     after("Perform test data clean up", function () {
         deleteByList(applicationsList);

--- a/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
@@ -129,290 +129,290 @@ describe(["@tier2"], "Source Analysis", () => {
         }
     );
 
-    it("Source + dependencies analysis on daytrader app", function () {
-        // Automate bug https://issues.redhat.com/browse/TACKLE-721
-        const application = new Analysis(
-            getRandomApplicationData("dayTraderApp_Source+dependencies", {
-                sourceData: this.appData["daytrader-app"],
-            }),
-            getRandomAnalysisData(this.analysisData["source+dep_analysis_on_daytrader-app"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.analyze();
-        // Daytrader app take more than 20 min to analyze
-        application.verifyAnalysisStatus("Completed", 30 * MIN);
-        application.verifyEffort(
-            this.analysisData["source+dep_analysis_on_daytrader-app"]["effort"]
-        );
-        application.validateIssues(
-            this.analysisData["source+dep_analysis_on_daytrader-app"]["issues"]
-        );
-        // Automate bug https://issues.redhat.com/browse/MTA-2006
-        this.analysisData["source+dep_analysis_on_daytrader-app"]["issues"].forEach(
-            (currentIssue: AppIssue) => {
-                application.validateAffected(currentIssue);
-            }
-        );
-    });
+    // it("Source + dependencies analysis on daytrader app", function () {
+    //     // Automate bug https://issues.redhat.com/browse/TACKLE-721
+    //     const application = new Analysis(
+    //         getRandomApplicationData("dayTraderApp_Source+dependencies", {
+    //             sourceData: this.appData["daytrader-app"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["source+dep_analysis_on_daytrader-app"])
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.analyze();
+    //     // Daytrader app take more than 20 min to analyze
+    //     application.verifyAnalysisStatus("Completed", 30 * MIN);
+    //     application.verifyEffort(
+    //         this.analysisData["source+dep_analysis_on_daytrader-app"]["effort"]
+    //     );
+    //     application.validateIssues(
+    //         this.analysisData["source+dep_analysis_on_daytrader-app"]["issues"]
+    //     );
+    //     // Automate bug https://issues.redhat.com/browse/MTA-2006
+    //     this.analysisData["source+dep_analysis_on_daytrader-app"]["issues"].forEach(
+    //         (currentIssue: AppIssue) => {
+    //             application.validateAffected(currentIssue);
+    //         }
+    //     );
+    // });
 
-    it("Analysis on daytrader app with maven credentials", function () {
-        // Automate bug https://issues.redhat.com/browse/TACKLE-751
-        const application = new Analysis(
-            getRandomApplicationData("dayTraderApp_MavenCreds", {
-                sourceData: this.appData["daytrader-app"],
-            }),
-            getRandomAnalysisData(this.analysisData["source+dep_analysis_on_daytrader-app"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.manageCredentials(null, mavenCredential.name);
-        application.analyze();
-        application.verifyAnalysisStatus("Completed");
-    });
+    // it("Analysis on daytrader app with maven credentials", function () {
+    //     // Automate bug https://issues.redhat.com/browse/TACKLE-751
+    //     const application = new Analysis(
+    //         getRandomApplicationData("dayTraderApp_MavenCreds", {
+    //             sourceData: this.appData["daytrader-app"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["source+dep_analysis_on_daytrader-app"])
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.manageCredentials(null, mavenCredential.name);
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed");
+    // });
 
-    it(["@tier1"], "Source Analysis on tackle testapp", function () {
-        // For tackle test app source credentials are required.
-        const application = new Analysis(
-            getRandomApplicationData("tackleTestApp_Source", {
-                sourceData: this.appData["tackle-testapp-git"],
-            }),
-            getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.manageCredentials(sourceCredential.name, null);
-        application.analyze();
-        application.verifyAnalysisStatus("Completed", 30 * MIN);
-    });
+    // it(["@tier1"], "Source Analysis on tackle testapp", function () {
+    //     // For tackle test app source credentials are required.
+    //     const application = new Analysis(
+    //         getRandomApplicationData("tackleTestApp_Source", {
+    //             sourceData: this.appData["tackle-testapp-git"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.manageCredentials(sourceCredential.name, null);
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed", 30 * MIN);
+    // });
 
-    it("Analysis on tackle test app with ssh credentials", function () {
-        // Automate bug https://issues.redhat.com/browse/TACKLE-707
-        const scCredsKey = new CredentialsSourceControlKey(
-            data.getRandomCredentialsData(
-                CredentialType.sourceControl,
-                UserCredentials.sourcePrivateKey
-            )
-        );
-        scCredsKey.create();
-        const application = new Analysis(
-            getRandomApplicationData("tackleTestApp_sshCreds", {
-                sourceData: this.appData["tackle-testapp-ssh"],
-            }),
-            getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.manageCredentials(scCredsKey.name, null);
-        application.analyze();
-        application.verifyAnalysisStatus("Completed");
-    });
+    // it("Analysis on tackle test app with ssh credentials", function () {
+    //     // Automate bug https://issues.redhat.com/browse/TACKLE-707
+    //     const scCredsKey = new CredentialsSourceControlKey(
+    //         data.getRandomCredentialsData(
+    //             CredentialType.sourceControl,
+    //             UserCredentials.sourcePrivateKey
+    //         )
+    //     );
+    //     scCredsKey.create();
+    //     const application = new Analysis(
+    //         getRandomApplicationData("tackleTestApp_sshCreds", {
+    //             sourceData: this.appData["tackle-testapp-ssh"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.manageCredentials(scCredsKey.name, null);
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed");
+    // });
 
-    it("Analysis for known Open Source libraries on tackleTest app", function () {
-        // Source code analysis require both source and maven credentials
-        const application = new Analysis(
-            getRandomApplicationData("tackleTestApp_Source+knownLibraries", {
-                sourceData: this.appData["tackle-testapp-git"],
-            }),
-            getRandomAnalysisData(this.analysisData["analysis_for_openSourceLibraries"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.manageCredentials(sourceCredential.name, mavenCredential.name);
-        application.analyze();
-        application.verifyAnalysisStatus("Completed", 30 * MIN);
-    });
+    // it("Analysis for known Open Source libraries on tackleTest app", function () {
+    //     // Source code analysis require both source and maven credentials
+    //     const application = new Analysis(
+    //         getRandomApplicationData("tackleTestApp_Source+knownLibraries", {
+    //             sourceData: this.appData["tackle-testapp-git"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["analysis_for_openSourceLibraries"])
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.manageCredentials(sourceCredential.name, mavenCredential.name);
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed", 30 * MIN);
+    // });
 
-    it("Automated tagging using Source Analysis on tackle testapp", function () {
-        // Automates Polarion MTA-208
-        const application = new Analysis(
-            getRandomApplicationData("tackleTestApp_Source_autoTagging", {
-                sourceData: this.appData["tackle-testapp-git"],
-            }),
-            getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.manageCredentials(sourceCredential.name, null);
-        application.analyze();
-        application.verifyAnalysisStatus("Completed");
-        application.applicationDetailsTab("Tags");
-        application.tagAndCategoryExists(
-            this.analysisData["analysis_for_enableTagging"]["techTags"]
-        );
-        application.closeApplicationDetails();
-    });
+    // it("Automated tagging using Source Analysis on tackle testapp", function () {
+    //     // Automates Polarion MTA-208
+    //     const application = new Analysis(
+    //         getRandomApplicationData("tackleTestApp_Source_autoTagging", {
+    //             sourceData: this.appData["tackle-testapp-git"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.manageCredentials(sourceCredential.name, null);
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed");
+    //     application.applicationDetailsTab("Tags");
+    //     application.tagAndCategoryExists(
+    //         this.analysisData["analysis_for_enableTagging"]["techTags"]
+    //     );
+    //     application.closeApplicationDetails();
+    // });
 
-    it("Bug MTA-3418: Disable Automated tagging using Source Analysis on bookServer app", function () {
-        // Automates Polarion MTA-307
-        const application = new Analysis(
-            getRandomApplicationData("bookserverApp_Disable_autoTagging", {
-                sourceData: this.appData["bookserver-app"],
-            }),
-            getRandomAnalysisData(this.analysisData["analysis_for_disableTagging"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.analyze();
-        application.verifyAnalysisStatus("Completed");
-        application.verifyEffort(this.analysisData["analysis_for_disableTagging"]["effort"]);
-        application.applicationDetailsTab("Tags");
-        cy.get("h2", { timeout: 5 * SEC }).should("contain", "No tags available");
-    });
+    // it("Bug MTA-3418: Disable Automated tagging using Source Analysis on bookServer app", function () {
+    //     // Automates Polarion MTA-307
+    //     const application = new Analysis(
+    //         getRandomApplicationData("bookserverApp_Disable_autoTagging", {
+    //             sourceData: this.appData["bookserver-app"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["analysis_for_disableTagging"])
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed");
+    //     application.verifyEffort(this.analysisData["analysis_for_disableTagging"]["effort"]);
+    //     application.applicationDetailsTab("Tags");
+    //     cy.get("h2", { timeout: 5 * SEC }).should("contain", "No tags available");
+    // });
 
-    it("Analysis for Konveyor example1 application", function () {
-        // Automates https://github.com/konveyor/example-applications/tree/main/example-1
-        const application = new Analysis(
-            getRandomApplicationData("Example 1", {
-                sourceData: this.appData["konveyor-exampleapp"],
-            }),
-            getRandomAnalysisData(this.analysisData["analysis_on_example-1-app"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.analyze();
-        application.verifyAnalysisStatus("Completed");
-        // Polarion TC 406
-        application.verifyEffort(this.analysisData["analysis_on_example-1-app"]["effort"]);
-    });
+    // it("Analysis for Konveyor example1 application", function () {
+    //     // Automates https://github.com/konveyor/example-applications/tree/main/example-1
+    //     const application = new Analysis(
+    //         getRandomApplicationData("Example 1", {
+    //             sourceData: this.appData["konveyor-exampleapp"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["analysis_on_example-1-app"])
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed");
+    //     // Polarion TC 406
+    //     application.verifyEffort(this.analysisData["analysis_on_example-1-app"]["effort"]);
+    // });
 
-    it("JWS6 target Source + deps analysis on tackletest app", function () {
-        // Source code analysis require both source and maven credentials
-        const application = new Analysis(
-            getRandomApplicationData("tackleTestApp_Source+dependencies_jws6", {
-                sourceData: this.appData["tackle-testapp-git"],
-            }),
-            getRandomAnalysisData(this.analysisData["jws6_source+dep_analysis_on_tackletestapp"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.manageCredentials(sourceCredential.name, mavenCredential.name);
-        application.analyze();
-        application.verifyAnalysisStatus("Completed");
-    });
+    // it("JWS6 target Source + deps analysis on tackletest app", function () {
+    //     // Source code analysis require both source and maven credentials
+    //     const application = new Analysis(
+    //         getRandomApplicationData("tackleTestApp_Source+dependencies_jws6", {
+    //             sourceData: this.appData["tackle-testapp-git"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["jws6_source+dep_analysis_on_tackletestapp"])
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.manageCredentials(sourceCredential.name, mavenCredential.name);
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed");
+    // });
 
-    it("Bug MTA-4412: Bug MTA-5212  Openjdk17 Source + dependencies analysis on tackletest app", function () {
-        const application = new Analysis(
-            getRandomApplicationData("tackleTestApp_Source+dependencies_openjdk17", {
-                sourceData: this.appData["tackle-testapp-git"],
-            }),
-            getRandomAnalysisData(
-                this.analysisData["openJDK17_source+dep_analysis_on_tackletestapp"]
-            )
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.manageCredentials(sourceCredential.name, mavenCredential.name);
-        application.analyze();
-        application.verifyAnalysisStatus("Completed");
-        application.verifyEffort(
-            this.analysisData["openJDK17_source+dep_analysis_on_tackletestapp"]["effort"]
-        );
-    });
+    // it("Bug MTA-4412: Bug MTA-5212  Openjdk17 Source + dependencies analysis on tackletest app", function () {
+    //     const application = new Analysis(
+    //         getRandomApplicationData("tackleTestApp_Source+dependencies_openjdk17", {
+    //             sourceData: this.appData["tackle-testapp-git"],
+    //         }),
+    //         getRandomAnalysisData(
+    //             this.analysisData["openJDK17_source+dep_analysis_on_tackletestapp"]
+    //         )
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.manageCredentials(sourceCredential.name, mavenCredential.name);
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed");
+    //     application.verifyEffort(
+    //         this.analysisData["openJDK17_source+dep_analysis_on_tackletestapp"]["effort"]
+    //     );
+    // });
 
-    it("OpenJDK21 Source + dependencies analysis on daytrader app", function () {
-        const application = new Analysis(
-            getRandomApplicationData("dayTraderApp_Source+dependencies_openjdk21", {
-                sourceData: this.appData["daytrader-app"],
-            }),
-            getRandomAnalysisData(this.analysisData["openJDK21_source+dep_analysis_on_dayTrader"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.analyze();
-        application.verifyAnalysisStatus("Completed", 30 * MIN);
-        application.verifyEffort(
-            this.analysisData["openJDK21_source+dep_analysis_on_dayTrader"]["effort"]
-        );
-    });
+    // it("OpenJDK21 Source + dependencies analysis on daytrader app", function () {
+    //     const application = new Analysis(
+    //         getRandomApplicationData("dayTraderApp_Source+dependencies_openjdk21", {
+    //             sourceData: this.appData["daytrader-app"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["openJDK21_source+dep_analysis_on_dayTrader"])
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed", 30 * MIN);
+    //     application.verifyEffort(
+    //         this.analysisData["openJDK21_source+dep_analysis_on_dayTrader"]["effort"]
+    //     );
+    // });
 
-    // Automates customer bug MTA-1785
-    it("JDK<11 Source + dependencies analysis on tackle app public", function () {
-        const application = new Analysis(
-            getRandomApplicationData("tackle testapp public jdk 9", {
-                sourceData: this.appData["tackle-testapp-public-jdk9"],
-            }),
-            getRandomAnalysisData(this.analysisData["jdk9_source_dep_analysis_on_tackletestapp"])
-        );
-        application.create();
-        application.manageCredentials(null, mavenCredential.name);
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.analyze();
-        application.verifyAnalysisStatus(AnalysisStatuses.completed);
-    });
+    // // Automates customer bug MTA-1785
+    // it("JDK<11 Source + dependencies analysis on tackle app public", function () {
+    //     const application = new Analysis(
+    //         getRandomApplicationData("tackle testapp public jdk 9", {
+    //             sourceData: this.appData["tackle-testapp-public-jdk9"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["jdk9_source_dep_analysis_on_tackletestapp"])
+    //     );
+    //     application.create();
+    //     application.manageCredentials(null, mavenCredential.name);
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.analyze();
+    //     application.verifyAnalysisStatus(AnalysisStatuses.completed);
+    // });
 
-    // Automates bug MTA-3422
-    it("4 targets source analysis on tackle app public", function () {
-        const application = new Analysis(
-            getRandomApplicationData("tackle-public-4-targets", {
-                sourceData: this.appData["tackle-testapp-public"],
-            }),
-            getRandomAnalysisData(this.analysisData["tackle-testapp-public-4-targets"])
-        );
-        application.create();
-        applicationsList.push(application);
-        application.analyze();
-        application.verifyAnalysisStatus("Completed");
-        application.verifyEffort(this.analysisData["tackle-testapp-public-4-targets"]["effort"]);
-    });
+    // // Automates bug MTA-3422
+    // it("4 targets source analysis on tackle app public", function () {
+    //     const application = new Analysis(
+    //         getRandomApplicationData("tackle-public-4-targets", {
+    //             sourceData: this.appData["tackle-testapp-public"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["tackle-testapp-public-4-targets"])
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed");
+    //     application.verifyEffort(this.analysisData["tackle-testapp-public-4-targets"]["effort"]);
+    // });
 
-    // Automates customer bug MTA-2973
-    it("Source analysis on tackle app public with custom rule", function () {
-        for (let i = 0; i < 2; i++) {
-            const application = new Analysis(
-                getRandomApplicationData("tackle-public-customRule", {
-                    sourceData: this.appData["tackle-testapp-public"],
-                }),
-                getRandomAnalysisData(this.analysisData["tackle-testapp-public-customRule"])
-            );
-            applicationsList.push(application);
-        }
+    // // Automates customer bug MTA-2973
+    // it("Source analysis on tackle app public with custom rule", function () {
+    //     for (let i = 0; i < 2; i++) {
+    //         const application = new Analysis(
+    //             getRandomApplicationData("tackle-public-customRule", {
+    //                 sourceData: this.appData["tackle-testapp-public"],
+    //             }),
+    //             getRandomAnalysisData(this.analysisData["tackle-testapp-public-customRule"])
+    //         );
+    //         applicationsList.push(application);
+    //     }
 
-        // Analyze an application
-        const analyzeApplication = (application, credentials) => {
-            application.create();
-            if (credentials) application.manageCredentials(null, credentials.name);
-            application.analyze();
-            application.verifyAnalysisStatus("Completed");
-            application.validateIssues(
-                this.analysisData["tackle-testapp-public-customRule"]["issues"]
-            );
-        };
+    //     // Analyze an application
+    //     const analyzeApplication = (application, credentials) => {
+    //         application.create();
+    //         if (credentials) application.manageCredentials(null, credentials.name);
+    //         application.analyze();
+    //         application.verifyAnalysisStatus("Completed");
+    //         application.validateIssues(
+    //             this.analysisData["tackle-testapp-public-customRule"]["issues"]
+    //         );
+    //     };
 
-        // Analyze application with Maven credentials
-        analyzeApplication(applicationsList[0], mavenCredential);
+    //     // Analyze application with Maven credentials
+    //     analyzeApplication(applicationsList[0], mavenCredential);
 
-        // Analyze application without Maven credentials
-        analyzeApplication(applicationsList[1], null);
-    });
+    //     // Analyze application without Maven credentials
+    //     analyzeApplication(applicationsList[1], null);
+    // });
 
-    it("Bug MTA-3701: Source analysis on tackle app with hash in Password", function () {
-        const application = new Analysis(
-            getRandomApplicationData("tackleTestApp_Source", {
-                sourceData: this.appData["tackle-testapp-git"],
-            }),
-            getRandomAnalysisData(this.analysisData["tackleTestApp_Source"])
-        );
+    // it("Bug MTA-3701: Source analysis on tackle app with hash in Password", function () {
+    //     const application = new Analysis(
+    //         getRandomApplicationData("tackleTestApp_Source", {
+    //             sourceData: this.appData["tackle-testapp-git"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["tackleTestApp_Source"])
+    //     );
 
-        // Analysis application with source credential created with hash
-        application.create();
-        application.manageCredentials(sourceCredentialWithHash.name);
-        applicationsList.push(application);
-        application.analyze();
-        application.verifyAnalysisStatus("Completed");
-    });
+    //     // Analysis application with source credential created with hash
+    //     application.create();
+    //     application.manageCredentials(sourceCredentialWithHash.name);
+    //     applicationsList.push(application);
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed");
+    // });
 
     after("Perform test data clean up", function () {
         deleteByList(applicationsList);

--- a/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
@@ -36,9 +36,11 @@ import {
     UserCredentials,
 } from "../../../../types/constants";
 import { AppIssue } from "../../../../types/types";
-let source_credential: CredentialsSourceControlUsername;
-let source_credential_withHash: CredentialsSourceControlUsername;
-let maven_credential: CredentialsMaven;
+let sourceCredential: CredentialsSourceControlUsername;
+let defaultSourceCredential: CredentialsSourceControlUsername;
+let sourceCredentialWithHash: CredentialsSourceControlUsername;
+let mavenCredential: CredentialsMaven;
+let defaultMavenCredential: CredentialsMaven;
 let applicationsList: Array<Analysis> = [];
 
 describe(["@tier2"], "Source Analysis", () => {
@@ -47,31 +49,49 @@ describe(["@tier2"], "Source Analysis", () => {
         cy.visit("/");
 
         // Create source Credentials
-        source_credential = new CredentialsSourceControlUsername(
+        sourceCredential = new CredentialsSourceControlUsername(
             data.getRandomCredentialsData(
                 CredentialType.sourceControl,
                 UserCredentials.usernamePassword,
                 true
             )
         );
-        source_credential.create();
+        sourceCredential.create();
+
+        // Create default source Credentials
+        defaultSourceCredential = new CredentialsSourceControlUsername(
+            data.getRandomCredentialsData(
+                CredentialType.sourceControl,
+                UserCredentials.usernamePassword,
+                false,
+                null,
+                true
+            )
+        );
+        defaultSourceCredential.create();
 
         // Create source Credentials with # in password
-        source_credential_withHash = new CredentialsSourceControlUsername(
+        sourceCredentialWithHash = new CredentialsSourceControlUsername(
             data.getRandomCredentialsData(
                 CredentialType.sourceControl,
                 UserCredentials.usernamePassword,
                 true
             )
         );
-        source_credential_withHash.password = "#" + source_credential_withHash.password;
-        source_credential_withHash.create();
+        sourceCredentialWithHash.password = "#" + sourceCredentialWithHash.password;
+        sourceCredentialWithHash.create();
 
         // Create Maven credentials
-        maven_credential = new CredentialsMaven(
+        mavenCredential = new CredentialsMaven(
             data.getRandomCredentialsData(CredentialType.maven, null, true)
         );
-        maven_credential.create();
+        mavenCredential.create();
+
+        // Create default Maven credentials
+        defaultMavenCredential = new CredentialsMaven(
+            data.getRandomCredentialsData(CredentialType.maven, null, false, null, true)
+        );
+        defaultMavenCredential.create();
     });
 
     beforeEach("Load data", function () {
@@ -89,24 +109,27 @@ describe(["@tier2"], "Source Analysis", () => {
         cy.visit("/");
     });
 
-    it(["@tier1"], "Source + dependencies analysis on tackletest app", function () {
-        // Source code analysis require both source and maven credentials
-        const application = new Analysis(
-            getRandomApplicationData("tackleTestApp_Source+dependencies", {
-                sourceData: this.appData["tackle-testapp-git"],
-            }),
-            getRandomAnalysisData(this.analysisData["source+dep_analysis_on_tackletestapp"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.manageCredentials(source_credential.name, maven_credential.name);
-        application.analyze();
-        application.verifyAnalysisStatus("Completed");
-        application.verifyEffort(
-            this.analysisData["source+dep_analysis_on_tackletestapp"]["effort"]
-        );
-    });
+    it(
+        ["@tier1"],
+        "Source + dependencies analysis on tackletest app with default credentials",
+        function () {
+            // Source code analysis require both source and maven credentials
+            const application = new Analysis(
+                getRandomApplicationData("tackleTestApp_Source+dependencies", {
+                    sourceData: this.appData["tackle-testapp-git"],
+                }),
+                getRandomAnalysisData(this.analysisData["source+dep_analysis_on_tackletestapp"])
+            );
+            application.create();
+            applicationsList.push(application);
+            cy.wait("@getApplication");
+            application.analyze();
+            application.verifyAnalysisStatus("Completed");
+            application.verifyEffort(
+                this.analysisData["source+dep_analysis_on_tackletestapp"]["effort"]
+            );
+        }
+    );
 
     it("Source + dependencies analysis on daytrader app", function () {
         // Automate bug https://issues.redhat.com/browse/TACKLE-721
@@ -147,7 +170,7 @@ describe(["@tier2"], "Source Analysis", () => {
         application.create();
         applicationsList.push(application);
         cy.wait("@getApplication");
-        application.manageCredentials(null, maven_credential.name);
+        application.manageCredentials(null, mavenCredential.name);
         application.analyze();
         application.verifyAnalysisStatus("Completed");
     });
@@ -163,7 +186,7 @@ describe(["@tier2"], "Source Analysis", () => {
         application.create();
         applicationsList.push(application);
         cy.wait("@getApplication");
-        application.manageCredentials(source_credential.name, null);
+        application.manageCredentials(sourceCredential.name, null);
         application.analyze();
         application.verifyAnalysisStatus("Completed", 30 * MIN);
     });
@@ -202,7 +225,7 @@ describe(["@tier2"], "Source Analysis", () => {
         application.create();
         applicationsList.push(application);
         cy.wait("@getApplication");
-        application.manageCredentials(source_credential.name, maven_credential.name);
+        application.manageCredentials(sourceCredential.name, mavenCredential.name);
         application.analyze();
         application.verifyAnalysisStatus("Completed", 30 * MIN);
     });
@@ -218,7 +241,7 @@ describe(["@tier2"], "Source Analysis", () => {
         application.create();
         applicationsList.push(application);
         cy.wait("@getApplication");
-        application.manageCredentials(source_credential.name, null);
+        application.manageCredentials(sourceCredential.name, null);
         application.analyze();
         application.verifyAnalysisStatus("Completed");
         application.applicationDetailsTab("Tags");
@@ -274,7 +297,7 @@ describe(["@tier2"], "Source Analysis", () => {
         application.create();
         applicationsList.push(application);
         cy.wait("@getApplication");
-        application.manageCredentials(source_credential.name, maven_credential.name);
+        application.manageCredentials(sourceCredential.name, mavenCredential.name);
         application.analyze();
         application.verifyAnalysisStatus("Completed");
         application.verifyEffort(
@@ -294,7 +317,7 @@ describe(["@tier2"], "Source Analysis", () => {
         application.create();
         applicationsList.push(application);
         cy.wait("@getApplication");
-        application.manageCredentials(source_credential.name, maven_credential.name);
+        application.manageCredentials(sourceCredential.name, mavenCredential.name);
         application.analyze();
         application.verifyAnalysisStatus("Completed");
         application.verifyEffort(
@@ -328,7 +351,7 @@ describe(["@tier2"], "Source Analysis", () => {
             getRandomAnalysisData(this.analysisData["jdk9_source_dep_analysis_on_tackletestapp"])
         );
         application.create();
-        application.manageCredentials(null, maven_credential.name);
+        application.manageCredentials(null, mavenCredential.name);
         applicationsList.push(application);
         cy.wait("@getApplication");
         application.analyze();
@@ -376,7 +399,7 @@ describe(["@tier2"], "Source Analysis", () => {
         };
 
         // Analyze application with Maven credentials
-        analyzeApplication(applicationsList[0], maven_credential);
+        analyzeApplication(applicationsList[0], mavenCredential);
 
         // Analyze application without Maven credentials
         analyzeApplication(applicationsList[1], null);
@@ -392,7 +415,7 @@ describe(["@tier2"], "Source Analysis", () => {
 
         // Analysis application with source credential created with hash
         application.create();
-        application.manageCredentials(source_credential_withHash.name);
+        application.manageCredentials(sourceCredentialWithHash.name);
         applicationsList.push(application);
         application.analyze();
         application.verifyAnalysisStatus("Completed");
@@ -403,14 +426,14 @@ describe(["@tier2"], "Source Analysis", () => {
         cy.visit("/");
         Application.open(true);
         deleteByList(applicationsList);
-        if (source_credential) {
-            source_credential.delete();
+        if (sourceCredential) {
+            sourceCredential.delete();
         }
-        if (maven_credential) {
-            maven_credential.delete();
+        if (mavenCredential) {
+            mavenCredential.delete();
         }
-        if (source_credential_withHash) {
-            source_credential_withHash.delete();
+        if (sourceCredentialWithHash) {
+            sourceCredentialWithHash.delete();
         }
         writeMavenSettingsFile(data.getRandomWord(5), data.getRandomWord(5));
     });

--- a/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
@@ -21,13 +21,11 @@ import {
     getRandomAnalysisData,
     getRandomApplicationData,
     login,
-    writeMavenSettingsFile,
 } from "../../../../../utils/utils";
 import { CredentialsMaven } from "../../../../models/administration/credentials/credentialsMaven";
 import { CredentialsSourceControlKey } from "../../../../models/administration/credentials/credentialsSourceControlKey";
 import { CredentialsSourceControlUsername } from "../../../../models/administration/credentials/credentialsSourceControlUsername";
 import { Analysis } from "../../../../models/migration/applicationinventory/analysis";
-import { Application } from "../../../../models/migration/applicationinventory/application";
 import {
     AnalysisStatuses,
     CredentialType,
@@ -422,19 +420,11 @@ describe(["@tier2"], "Source Analysis", () => {
     });
 
     after("Perform test data clean up", function () {
-        login();
-        cy.visit("/");
-        Application.open(true);
         deleteByList(applicationsList);
-        if (sourceCredential) {
-            sourceCredential.delete();
-        }
-        if (mavenCredential) {
-            mavenCredential.delete();
-        }
-        if (sourceCredentialWithHash) {
-            sourceCredentialWithHash.delete();
-        }
-        writeMavenSettingsFile(data.getRandomWord(5), data.getRandomWord(5));
+        sourceCredential.delete();
+        defaultSourceCredential.delete();
+        sourceCredentialWithHash.delete();
+        mavenCredential.delete();
+        defaultMavenCredential.delete();
     });
 });

--- a/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
@@ -36,9 +36,9 @@ import {
     UserCredentials,
 } from "../../../../types/constants";
 import { AppIssue } from "../../../../types/types";
-let defaultSourceCredential: CredentialsSourceControlUsername;
+let source_credential: CredentialsSourceControlUsername;
 let source_credential_withHash: CredentialsSourceControlUsername;
-let defaultMavenCredential: CredentialsMaven;
+let maven_credential: CredentialsMaven;
 let applicationsList: Array<Analysis> = [];
 
 describe(["@tier2"], "Source Analysis", () => {
@@ -47,16 +47,14 @@ describe(["@tier2"], "Source Analysis", () => {
         cy.visit("/");
 
         // Create source Credentials
-        defaultSourceCredential = new CredentialsSourceControlUsername(
+        source_credential = new CredentialsSourceControlUsername(
             data.getRandomCredentialsData(
                 CredentialType.sourceControl,
                 UserCredentials.usernamePassword,
-                true,
-                null,
                 true
             )
         );
-        defaultSourceCredential.create();
+        source_credential.create();
 
         // Create source Credentials with # in password
         source_credential_withHash = new CredentialsSourceControlUsername(
@@ -70,10 +68,10 @@ describe(["@tier2"], "Source Analysis", () => {
         source_credential_withHash.create();
 
         // Create Maven credentials
-        defaultMavenCredential = new CredentialsMaven(
-            data.getRandomCredentialsData(CredentialType.maven, null, true, null, true)
+        maven_credential = new CredentialsMaven(
+            data.getRandomCredentialsData(CredentialType.maven, null, true)
         );
-        defaultMavenCredential.create();
+        maven_credential.create();
     });
 
     beforeEach("Load data", function () {
@@ -91,27 +89,24 @@ describe(["@tier2"], "Source Analysis", () => {
         cy.visit("/");
     });
 
-    it(
-        ["@tier1"],
-        "Source + dependencies analysis on tackletest app with default credentials",
-        function () {
-            // Source code analysis require both source and maven credentials
-            const application = new Analysis(
-                getRandomApplicationData("tackleTestApp_Source+dependencies", {
-                    sourceData: this.appData["tackle-testapp-git"],
-                }),
-                getRandomAnalysisData(this.analysisData["source+dep_analysis_on_tackletestapp"])
-            );
-            application.create();
-            applicationsList.push(application);
-            cy.wait("@getApplication");
-            application.analyze();
-            application.verifyAnalysisStatus("Completed");
-            application.verifyEffort(
-                this.analysisData["source+dep_analysis_on_tackletestapp"]["effort"]
-            );
-        }
-    );
+    it(["@tier1"], "Source + dependencies analysis on tackletest app", function () {
+        // Source code analysis require both source and maven credentials
+        const application = new Analysis(
+            getRandomApplicationData("tackleTestApp_Source+dependencies", {
+                sourceData: this.appData["tackle-testapp-git"],
+            }),
+            getRandomAnalysisData(this.analysisData["source+dep_analysis_on_tackletestapp"])
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.manageCredentials(source_credential.name, maven_credential.name);
+        application.analyze();
+        application.verifyAnalysisStatus("Completed");
+        application.verifyEffort(
+            this.analysisData["source+dep_analysis_on_tackletestapp"]["effort"]
+        );
+    });
 
     it("Source + dependencies analysis on daytrader app", function () {
         // Automate bug https://issues.redhat.com/browse/TACKLE-721
@@ -152,7 +147,7 @@ describe(["@tier2"], "Source Analysis", () => {
         application.create();
         applicationsList.push(application);
         cy.wait("@getApplication");
-        application.manageCredentials(null, defaultMavenCredential.name);
+        application.manageCredentials(null, maven_credential.name);
         application.analyze();
         application.verifyAnalysisStatus("Completed");
     });
@@ -168,7 +163,7 @@ describe(["@tier2"], "Source Analysis", () => {
         application.create();
         applicationsList.push(application);
         cy.wait("@getApplication");
-        application.manageCredentials(defaultSourceCredential.name, null);
+        application.manageCredentials(source_credential.name, null);
         application.analyze();
         application.verifyAnalysisStatus("Completed", 30 * MIN);
     });
@@ -207,6 +202,7 @@ describe(["@tier2"], "Source Analysis", () => {
         application.create();
         applicationsList.push(application);
         cy.wait("@getApplication");
+        application.manageCredentials(source_credential.name, maven_credential.name);
         application.analyze();
         application.verifyAnalysisStatus("Completed", 30 * MIN);
     });
@@ -222,7 +218,7 @@ describe(["@tier2"], "Source Analysis", () => {
         application.create();
         applicationsList.push(application);
         cy.wait("@getApplication");
-        application.manageCredentials(defaultSourceCredential.name, null);
+        application.manageCredentials(source_credential.name, null);
         application.analyze();
         application.verifyAnalysisStatus("Completed");
         application.applicationDetailsTab("Tags");
@@ -278,7 +274,7 @@ describe(["@tier2"], "Source Analysis", () => {
         application.create();
         applicationsList.push(application);
         cy.wait("@getApplication");
-        application.manageCredentials(defaultSourceCredential.name, defaultMavenCredential.name);
+        application.manageCredentials(source_credential.name, maven_credential.name);
         application.analyze();
         application.verifyAnalysisStatus("Completed");
         application.verifyEffort(
@@ -298,7 +294,7 @@ describe(["@tier2"], "Source Analysis", () => {
         application.create();
         applicationsList.push(application);
         cy.wait("@getApplication");
-        application.manageCredentials(defaultSourceCredential.name, defaultMavenCredential.name);
+        application.manageCredentials(source_credential.name, maven_credential.name);
         application.analyze();
         application.verifyAnalysisStatus("Completed");
         application.verifyEffort(
@@ -332,7 +328,7 @@ describe(["@tier2"], "Source Analysis", () => {
             getRandomAnalysisData(this.analysisData["jdk9_source_dep_analysis_on_tackletestapp"])
         );
         application.create();
-        application.manageCredentials(null, defaultMavenCredential.name);
+        application.manageCredentials(null, maven_credential.name);
         applicationsList.push(application);
         cy.wait("@getApplication");
         application.analyze();
@@ -380,7 +376,7 @@ describe(["@tier2"], "Source Analysis", () => {
         };
 
         // Analyze application with Maven credentials
-        analyzeApplication(applicationsList[0], defaultMavenCredential);
+        analyzeApplication(applicationsList[0], maven_credential);
 
         // Analyze application without Maven credentials
         analyzeApplication(applicationsList[1], null);
@@ -407,11 +403,11 @@ describe(["@tier2"], "Source Analysis", () => {
         cy.visit("/");
         Application.open(true);
         deleteByList(applicationsList);
-        if (defaultSourceCredential) {
-            defaultSourceCredential.delete();
+        if (source_credential) {
+            source_credential.delete();
         }
-        if (defaultMavenCredential) {
-            defaultMavenCredential.delete();
+        if (maven_credential) {
+            maven_credential.delete();
         }
         if (source_credential_withHash) {
             source_credential_withHash.delete();

--- a/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
@@ -21,6 +21,7 @@ import {
     getRandomAnalysisData,
     getRandomApplicationData,
     login,
+    writeMavenSettingsFile,
 } from "../../../../../utils/utils";
 import { CredentialsMaven } from "../../../../models/administration/credentials/credentialsMaven";
 import { CredentialsSourceControlKey } from "../../../../models/administration/credentials/credentialsSourceControlKey";
@@ -421,5 +422,6 @@ describe(["@tier2"], "Source Analysis", () => {
         sourceCredentialWithHash.delete();
         mavenCredential.delete();
         defaultMavenCredential.delete();
+        writeMavenSettingsFile(data.getRandomWord(5), data.getRandomWord(5));
     });
 });

--- a/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
@@ -36,9 +36,9 @@ import {
     UserCredentials,
 } from "../../../../types/constants";
 import { AppIssue } from "../../../../types/types";
-let source_credential: CredentialsSourceControlUsername;
+let defaultSourceCredential: CredentialsSourceControlUsername;
 let source_credential_withHash: CredentialsSourceControlUsername;
-let maven_credential: CredentialsMaven;
+let defaultMavenCredential: CredentialsMaven;
 let applicationsList: Array<Analysis> = [];
 
 describe(["@tier2"], "Source Analysis", () => {
@@ -47,14 +47,16 @@ describe(["@tier2"], "Source Analysis", () => {
         cy.visit("/");
 
         // Create source Credentials
-        source_credential = new CredentialsSourceControlUsername(
+        defaultSourceCredential = new CredentialsSourceControlUsername(
             data.getRandomCredentialsData(
                 CredentialType.sourceControl,
                 UserCredentials.usernamePassword,
+                true,
+                null,
                 true
             )
         );
-        source_credential.create();
+        defaultSourceCredential.create();
 
         // Create source Credentials with # in password
         source_credential_withHash = new CredentialsSourceControlUsername(
@@ -68,10 +70,10 @@ describe(["@tier2"], "Source Analysis", () => {
         source_credential_withHash.create();
 
         // Create Maven credentials
-        maven_credential = new CredentialsMaven(
-            data.getRandomCredentialsData(CredentialType.maven, null, true)
+        defaultMavenCredential = new CredentialsMaven(
+            data.getRandomCredentialsData(CredentialType.maven, null, true, null, true)
         );
-        maven_credential.create();
+        defaultMavenCredential.create();
     });
 
     beforeEach("Load data", function () {
@@ -89,24 +91,27 @@ describe(["@tier2"], "Source Analysis", () => {
         cy.visit("/");
     });
 
-    it(["@tier1"], "Source + dependencies analysis on tackletest app", function () {
-        // Source code analysis require both source and maven credentials
-        const application = new Analysis(
-            getRandomApplicationData("tackleTestApp_Source+dependencies", {
-                sourceData: this.appData["tackle-testapp-git"],
-            }),
-            getRandomAnalysisData(this.analysisData["source+dep_analysis_on_tackletestapp"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.manageCredentials(source_credential.name, maven_credential.name);
-        application.analyze();
-        application.verifyAnalysisStatus("Completed");
-        application.verifyEffort(
-            this.analysisData["source+dep_analysis_on_tackletestapp"]["effort"]
-        );
-    });
+    it(
+        ["@tier1"],
+        "Source + dependencies analysis on tackletest app with default credentials",
+        function () {
+            // Source code analysis require both source and maven credentials
+            const application = new Analysis(
+                getRandomApplicationData("tackleTestApp_Source+dependencies", {
+                    sourceData: this.appData["tackle-testapp-git"],
+                }),
+                getRandomAnalysisData(this.analysisData["source+dep_analysis_on_tackletestapp"])
+            );
+            application.create();
+            applicationsList.push(application);
+            cy.wait("@getApplication");
+            application.analyze();
+            application.verifyAnalysisStatus("Completed");
+            application.verifyEffort(
+                this.analysisData["source+dep_analysis_on_tackletestapp"]["effort"]
+            );
+        }
+    );
 
     it("Source + dependencies analysis on daytrader app", function () {
         // Automate bug https://issues.redhat.com/browse/TACKLE-721
@@ -147,7 +152,7 @@ describe(["@tier2"], "Source Analysis", () => {
         application.create();
         applicationsList.push(application);
         cy.wait("@getApplication");
-        application.manageCredentials(null, maven_credential.name);
+        application.manageCredentials(null, defaultMavenCredential.name);
         application.analyze();
         application.verifyAnalysisStatus("Completed");
     });
@@ -163,7 +168,7 @@ describe(["@tier2"], "Source Analysis", () => {
         application.create();
         applicationsList.push(application);
         cy.wait("@getApplication");
-        application.manageCredentials(source_credential.name, null);
+        application.manageCredentials(defaultSourceCredential.name, null);
         application.analyze();
         application.verifyAnalysisStatus("Completed", 30 * MIN);
     });
@@ -202,7 +207,6 @@ describe(["@tier2"], "Source Analysis", () => {
         application.create();
         applicationsList.push(application);
         cy.wait("@getApplication");
-        application.manageCredentials(source_credential.name, maven_credential.name);
         application.analyze();
         application.verifyAnalysisStatus("Completed", 30 * MIN);
     });
@@ -218,7 +222,7 @@ describe(["@tier2"], "Source Analysis", () => {
         application.create();
         applicationsList.push(application);
         cy.wait("@getApplication");
-        application.manageCredentials(source_credential.name, null);
+        application.manageCredentials(defaultSourceCredential.name, null);
         application.analyze();
         application.verifyAnalysisStatus("Completed");
         application.applicationDetailsTab("Tags");
@@ -274,7 +278,7 @@ describe(["@tier2"], "Source Analysis", () => {
         application.create();
         applicationsList.push(application);
         cy.wait("@getApplication");
-        application.manageCredentials(source_credential.name, maven_credential.name);
+        application.manageCredentials(defaultSourceCredential.name, defaultMavenCredential.name);
         application.analyze();
         application.verifyAnalysisStatus("Completed");
         application.verifyEffort(
@@ -294,7 +298,7 @@ describe(["@tier2"], "Source Analysis", () => {
         application.create();
         applicationsList.push(application);
         cy.wait("@getApplication");
-        application.manageCredentials(source_credential.name, maven_credential.name);
+        application.manageCredentials(defaultSourceCredential.name, defaultMavenCredential.name);
         application.analyze();
         application.verifyAnalysisStatus("Completed");
         application.verifyEffort(
@@ -328,7 +332,7 @@ describe(["@tier2"], "Source Analysis", () => {
             getRandomAnalysisData(this.analysisData["jdk9_source_dep_analysis_on_tackletestapp"])
         );
         application.create();
-        application.manageCredentials(null, maven_credential.name);
+        application.manageCredentials(null, defaultMavenCredential.name);
         applicationsList.push(application);
         cy.wait("@getApplication");
         application.analyze();
@@ -376,7 +380,7 @@ describe(["@tier2"], "Source Analysis", () => {
         };
 
         // Analyze application with Maven credentials
-        analyzeApplication(applicationsList[0], maven_credential);
+        analyzeApplication(applicationsList[0], defaultMavenCredential);
 
         // Analyze application without Maven credentials
         analyzeApplication(applicationsList[1], null);
@@ -403,11 +407,11 @@ describe(["@tier2"], "Source Analysis", () => {
         cy.visit("/");
         Application.open(true);
         deleteByList(applicationsList);
-        if (source_credential) {
-            source_credential.delete();
+        if (defaultSourceCredential) {
+            defaultSourceCredential.delete();
         }
-        if (maven_credential) {
-            maven_credential.delete();
+        if (defaultMavenCredential) {
+            defaultMavenCredential.delete();
         }
         if (source_credential_withHash) {
             source_credential_withHash.delete();

--- a/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
@@ -61,7 +61,7 @@ describe(["@tier2"], "Source Analysis", () => {
             data.getRandomCredentialsData(
                 CredentialType.sourceControl,
                 UserCredentials.usernamePassword,
-                false,
+                true,
                 null,
                 true
             )
@@ -87,7 +87,7 @@ describe(["@tier2"], "Source Analysis", () => {
 
         // Create default Maven credentials
         defaultMavenCredential = new CredentialsMaven(
-            data.getRandomCredentialsData(CredentialType.maven, null, false, null, true)
+            data.getRandomCredentialsData(CredentialType.maven, null, true, null, true)
         );
         defaultMavenCredential.create();
     });

--- a/cypress/fixtures/analysis.json
+++ b/cypress/fixtures/analysis.json
@@ -794,7 +794,7 @@
         "source": "Source code + dependencies",
         "target": ["Jakarta EE 9", "Containerization", "Quarkus"],
         "appName": "deps",
-        "effort": 1006,
+        "effort": 957,
         "issues": [
             {
                 "name": "@MessageDriven - EJBs are not supported in Quarkus",
@@ -1372,7 +1372,7 @@
         "source": "Source code + dependencies",
         "target": ["Jakarta EE 9", "Containerization"],
         "appName": "tackle-testapp",
-        "effort": 547,
+        "effort": 598,
         "openSourceLibraries": true
     },
 
@@ -2005,7 +2005,7 @@
         "target": ["JBoss Web Server 6"],
         "appName": "tackle-testapp",
         "openSourceLibraries": true,
-        "effort": 36
+        "effort": 34
     },
 
     "openJDK17_source+dep_analysis_on_tackletestapp": {
@@ -2060,7 +2060,7 @@
         "appName": "tackle-testapp-public",
         "source": "Source code",
         "target": ["Application server migration to", "OpenJDK", "Containerization", "Linux"],
-        "effort": 14
+        "effort": 20
     },
     "tackle-testapp-public": {
         "appName": "tackle-testapp-public",

--- a/cypress/fixtures/analysis.json
+++ b/cypress/fixtures/analysis.json
@@ -1372,7 +1372,7 @@
         "source": "Source code + dependencies",
         "target": ["Jakarta EE 9", "Containerization"],
         "appName": "tackle-testapp",
-        "effort": 598,
+        "effort": 547,
         "openSourceLibraries": true
     },
 

--- a/cypress/fixtures/analysis.json
+++ b/cypress/fixtures/analysis.json
@@ -794,7 +794,7 @@
         "source": "Source code + dependencies",
         "target": ["Jakarta EE 9", "Containerization", "Quarkus"],
         "appName": "deps",
-        "effort": 959,
+        "effort": 1006,
         "issues": [
             {
                 "name": "@MessageDriven - EJBs are not supported in Quarkus",
@@ -2005,7 +2005,7 @@
         "target": ["JBoss Web Server 6"],
         "appName": "tackle-testapp",
         "openSourceLibraries": true,
-        "effort": 34
+        "effort": 36
     },
 
     "openJDK17_source+dep_analysis_on_tackletestapp": {
@@ -2060,7 +2060,7 @@
         "appName": "tackle-testapp-public",
         "source": "Source code",
         "target": ["Application server migration to", "OpenJDK", "Containerization", "Linux"],
-        "effort": 20
+        "effort": 14
     },
     "tackle-testapp-public": {
         "appName": "tackle-testapp-public",


### PR DESCRIPTION
## Summary

Automates [MTA-707 - [DC] Analyze succeeds on an application using default credentials from source control and maven settings #1610](https://github.com/konveyor/tackle-ui-tests/issues/1610)

- Renamed variables for source and Maven credentials to reflect their default status.
- Updated test cases to utilize default credentials for source and Maven analysis.

## Jenkins Run

[mta 8.0.0-42](https://jenkins-csb-migrationqe-main.dno.corp.redhat.com/job/mta/job/mta-ui-tests-runner/5804/console)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Tests
  - Standardized credential handling and naming across end-to-end migration analysis tests.
  - Introduced default source control and Maven credentials to streamline setup and reduce redundancy.
  - Simplified test flows by relying on defaults; removed unnecessary setup steps and improved cleanup.
  - Updated test scenarios to consistently use the new credential approach, enhancing stability and maintainability.
  - No user-facing changes; improves test reliability and developer confidence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->