### PR TITLE
[TA][RFR] MTA-717 Creating Maven credentials then setting as default

### DIFF
--- a/cypress/e2e/models/administration/credentials/credentialsMaven.ts
+++ b/cypress/e2e/models/administration/credentials/credentialsMaven.ts
@@ -51,6 +51,11 @@ export class CredentialsMaven extends Credentials {
         super.verifyDefaultCredentialIcon();
     }
 
+    setAsDefaultViaActionsMenu() {
+        this.isDefault = true;
+        super.setAsDefaultViaActionsMenu();
+    }
+
     edit(credentialsMavenData: CredentialsMavenData, toBeCanceled = false) {
         const oldValues = this.storeOldValues();
         super.edit(oldValues);

--- a/cypress/e2e/tests/administration/credentials/maven_crud.test.ts
+++ b/cypress/e2e/tests/administration/credentials/maven_crud.test.ts
@@ -16,9 +16,10 @@ limitations under the License.
 /// <reference types="cypress" />
 
 import { getRandomCredentialsData } from "../../../../utils/data_utils";
-import { deleteByList } from "../../../../utils/utils";
+import { click, deleteByList } from "../../../../utils/utils";
 import { CredentialsMaven } from "../../../models/administration/credentials/credentialsMaven";
 import { CredentialType } from "../../../types/constants";
+import { confirmButton } from "../../../views/common.view";
 
 describe(["@tier3"], "Validation of Maven Credentials", () => {
     let mavenCredentials: CredentialsMaven[] = [];
@@ -38,6 +39,17 @@ describe(["@tier3"], "Validation of Maven Credentials", () => {
         defaultMavenCredentials.create();
         mavenCredentials.push(defaultMavenCredentials);
         defaultMavenCredentials.verifyDefaultCredentialIcon();
+    });
+
+    it("Creating Maven credentials then setting as default", () => {
+        const mavenCredentialsSetAsDefault = new CredentialsMaven(
+            getRandomCredentialsData(CredentialType.maven)
+        );
+        mavenCredentialsSetAsDefault.create();
+        mavenCredentials.push(mavenCredentialsSetAsDefault);
+        mavenCredentialsSetAsDefault.setAsDefaultViaActionsMenu();
+        click(confirmButton);
+        mavenCredentialsSetAsDefault.verifyDefaultCredentialIcon();
     });
 
     after("Cleaning up", () => {


### PR DESCRIPTION
Automates https://github.com/konveyor/tackle-ui-tests/issues/1609?issue=konveyor%7Ctackle-ui-tests%7C1620

## Test Run
[8.0.0-42](https://jenkins-csb-migrationqe-main.dno.corp.redhat.com/job/mta/job/mta-ui-tests-runner/)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added an end-to-end scenario for creating Maven credentials and setting one as the default via the actions menu.
  - Covered confirmation flow to ensure the default selection is applied and reflected in the UI.
  - Improved test utilities to support interactive confirmation and validation of the default indicator.
  - Enhanced reliability of credential management coverage, including creation and cleanup routines.
  - No user-facing changes; this improves confidence in the credentials administration experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->