### PR TITLE
[TA][RFR] Added TC to unset default maven credentials

### DIFF
--- a/cypress/e2e/models/administration/credentials/credentialsMaven.ts
+++ b/cypress/e2e/models/administration/credentials/credentialsMaven.ts
@@ -52,8 +52,11 @@ export class CredentialsMaven extends Credentials {
     }
 
     setAsDefaultViaActionsMenu() {
-        this.isDefault = true;
         super.setAsDefaultViaActionsMenu();
+    }
+
+    unsetAsDefaultViaActionsMenu() {
+        super.unsetAsDefaultViaActionsMenu();
     }
 
     edit(credentialsMavenData: CredentialsMavenData, toBeCanceled = false) {

--- a/cypress/e2e/tests/administration/credentials/maven_crud.test.ts
+++ b/cypress/e2e/tests/administration/credentials/maven_crud.test.ts
@@ -52,6 +52,20 @@ describe(["@tier3"], "Validation of Maven Credentials", () => {
         mavenCredentialsSetAsDefault.verifyDefaultCredentialIcon();
     });
 
+    it("Unsetting default Maven credentials after creating it", () => {
+        // Polarion TC: MTA-719
+        const tempDefaultCred = new CredentialsMaven(
+            getRandomCredentialsData(CredentialType.maven, null, false, null, true)
+        );
+
+        tempDefaultCred.create();
+        mavenCredentials.push(tempDefaultCred);
+        tempDefaultCred.verifyDefaultCredentialIcon();
+        tempDefaultCred.unsetAsDefaultViaActionsMenu();
+        click(confirmButton);
+        tempDefaultCred.verifyDefaultCredentialIcon();
+    });
+
     after("Cleaning up", () => {
         deleteByList(mavenCredentials);
     });


### PR DESCRIPTION
Enhance CredentialsMaven class with unset default functionality and add corresponding test case. This update introduces the `unsetAsDefaultViaActionsMenu` method and verifies the ability to unset default Maven credentials in the test suite.

Automates https://github.com/issues/assigned?issue=konveyor%7Ctackle-ui-tests%7C1622

## Test Run
[MTA 8.0.0-42](https://jenkins-csb-migrationqe-main.dno.corp.redhat.com/job/mta/job/mta-ui-tests-runner/5815/console)

<!-- Add pull request description here -->

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - No user-facing changes.

- Refactor
  - Simplified handling of “default” status for Maven credentials to align behaviors.
  - Exposed an action to unset the default status via the UI flow.

- Tests
  - Added an end-to-end scenario validating unsetting a default Maven credential after creation.
  - Verifies the default indicator updates correctly, increasing confidence in create/edit and default-toggling flows.

- Chores
  - Minor internal cleanup to reduce duplication and rely on shared behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->