### PR TITLE
[TA][RFR] Add test case for analysis failure without default credentials

### DIFF
--- a/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis_without_creds.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis_without_creds.test.ts
@@ -140,6 +140,20 @@ describe(["@tier1"], "Source Analysis without credentials", () => {
         application.verifyAnalysisStatus(AnalysisStatuses.canceled);
     });
 
+    it("Analysis should fail when no default credentials are available", function () {
+        const application = new Analysis(
+            getRandomApplicationData("tackleTestApp_Source+dependencies", {
+                sourceData: this.appData["tackle-testapp-git"],
+            }),
+            getRandomAnalysisData(this.analysisData["source+dep_analysis_on_tackletestapp"])
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.analyze();
+        application.verifyAnalysisStatus(AnalysisStatuses.failed);
+    });
+
     after("Perform test data clean up", function () {
         deleteByList(applicationsList);
     });

--- a/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis_without_creds.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis_without_creds.test.ts
@@ -140,7 +140,7 @@ describe(["@tier1"], "Source Analysis without credentials", () => {
         application.verifyAnalysisStatus(AnalysisStatuses.canceled);
     });
 
-    it("Analysis should fail when no default credentials are available", function () {
+    it("Analysis that requires credentials should fail when none are set", function () {
         const application = new Analysis(
             getRandomApplicationData("tackleTestApp_Source+dependencies", {
                 sourceData: this.appData["tackle-testapp-git"],


### PR DESCRIPTION
Automates https://github.com/issues/assigned?issue=konveyor%7Ctackle-ui-tests%7C1611

## Test Run

[MTA 8.0.0-42](https://jenkins-csb-migrationqe-main.dno.corp.redhat.com/job/mta/job/mta-ui-tests-runner/5817/console)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added end-to-end coverage for source analysis when no default credentials are present.
  * Adds a test verifying analysis fails visibly when credentials are not set.
  * Confirms the application list updates and the UI reports the failed analysis status.
  * Follows real user flows (create, run, verify) to improve realism of migration tests.
  * Increases confidence in error handling and prevents regressions in migration workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->