### PR TITLE
[TA][RFR] Analysis with default source credentials and manually set maven creds

### DIFF
--- a/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
@@ -108,113 +108,113 @@ describe(["@tier2"], "Source Analysis", () => {
         cy.visit("/");
     });
 
-    it(
-        ["@tier1"],
-        "Source + dependencies analysis on tackletest app with default credentials",
-        function () {
-            // Source code analysis require both source and maven credentials
-            const application = new Analysis(
-                getRandomApplicationData("tackleTestApp_Source+dependencies", {
-                    sourceData: this.appData["tackle-testapp-git"],
-                }),
-                getRandomAnalysisData(this.analysisData["source+dep_analysis_on_tackletestapp"])
-            );
-            application.create();
-            applicationsList.push(application);
-            cy.wait("@getApplication");
-            application.analyze();
-            application.verifyAnalysisStatus("Completed");
-            application.verifyEffort(
-                this.analysisData["source+dep_analysis_on_tackletestapp"]["effort"]
-            );
-        }
-    );
+    // it(
+    //     ["@tier1"],
+    //     "Source + dependencies analysis on tackletest app with default credentials",
+    //     function () {
+    //         // Source code analysis require both source and maven credentials
+    //         const application = new Analysis(
+    //             getRandomApplicationData("tackleTestApp_Source+dependencies", {
+    //                 sourceData: this.appData["tackle-testapp-git"],
+    //             }),
+    //             getRandomAnalysisData(this.analysisData["source+dep_analysis_on_tackletestapp"])
+    //         );
+    //         application.create();
+    //         applicationsList.push(application);
+    //         cy.wait("@getApplication");
+    //         application.analyze();
+    //         application.verifyAnalysisStatus("Completed");
+    //         application.verifyEffort(
+    //             this.analysisData["source+dep_analysis_on_tackletestapp"]["effort"]
+    //         );
+    //     }
+    // );
 
-    it("Source + dependencies analysis on daytrader app", function () {
-        // Automate bug https://issues.redhat.com/browse/TACKLE-721
-        const application = new Analysis(
-            getRandomApplicationData("dayTraderApp_Source+dependencies", {
-                sourceData: this.appData["daytrader-app"],
-            }),
-            getRandomAnalysisData(this.analysisData["source+dep_analysis_on_daytrader-app"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.analyze();
-        // Daytrader app take more than 20 min to analyze
-        application.verifyAnalysisStatus("Completed", 30 * MIN);
-        application.verifyEffort(
-            this.analysisData["source+dep_analysis_on_daytrader-app"]["effort"]
-        );
-        application.validateIssues(
-            this.analysisData["source+dep_analysis_on_daytrader-app"]["issues"]
-        );
-        // Automate bug https://issues.redhat.com/browse/MTA-2006
-        this.analysisData["source+dep_analysis_on_daytrader-app"]["issues"].forEach(
-            (currentIssue: AppIssue) => {
-                application.validateAffected(currentIssue);
-            }
-        );
-    });
+    // it("Source + dependencies analysis on daytrader app", function () {
+    //     // Automate bug https://issues.redhat.com/browse/TACKLE-721
+    //     const application = new Analysis(
+    //         getRandomApplicationData("dayTraderApp_Source+dependencies", {
+    //             sourceData: this.appData["daytrader-app"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["source+dep_analysis_on_daytrader-app"])
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.analyze();
+    //     // Daytrader app take more than 20 min to analyze
+    //     application.verifyAnalysisStatus("Completed", 30 * MIN);
+    //     application.verifyEffort(
+    //         this.analysisData["source+dep_analysis_on_daytrader-app"]["effort"]
+    //     );
+    //     application.validateIssues(
+    //         this.analysisData["source+dep_analysis_on_daytrader-app"]["issues"]
+    //     );
+    //     // Automate bug https://issues.redhat.com/browse/MTA-2006
+    //     this.analysisData["source+dep_analysis_on_daytrader-app"]["issues"].forEach(
+    //         (currentIssue: AppIssue) => {
+    //             application.validateAffected(currentIssue);
+    //         }
+    //     );
+    // });
 
-    it("Analysis on daytrader app with maven credentials", function () {
-        // Automate bug https://issues.redhat.com/browse/TACKLE-751
-        const application = new Analysis(
-            getRandomApplicationData("dayTraderApp_MavenCreds", {
-                sourceData: this.appData["daytrader-app"],
-            }),
-            getRandomAnalysisData(this.analysisData["source+dep_analysis_on_daytrader-app"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.manageCredentials(null, mavenCredential.name);
-        application.analyze();
-        application.verifyAnalysisStatus("Completed");
-    });
+    // it("Analysis on daytrader app with maven credentials", function () {
+    //     // Automate bug https://issues.redhat.com/browse/TACKLE-751
+    //     const application = new Analysis(
+    //         getRandomApplicationData("dayTraderApp_MavenCreds", {
+    //             sourceData: this.appData["daytrader-app"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["source+dep_analysis_on_daytrader-app"])
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.manageCredentials(null, mavenCredential.name);
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed");
+    // });
 
-    it(["@tier1"], "Source Analysis on tackle testapp", function () {
-        // For tackle test app source credentials are required.
-        const application = new Analysis(
-            getRandomApplicationData("tackleTestApp_Source", {
-                sourceData: this.appData["tackle-testapp-git"],
-            }),
-            getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.manageCredentials(sourceCredential.name, null);
-        application.analyze();
-        application.verifyAnalysisStatus("Completed", 30 * MIN);
-    });
+    // it(["@tier1"], "Source Analysis on tackle testapp", function () {
+    //     // For tackle test app source credentials are required.
+    //     const application = new Analysis(
+    //         getRandomApplicationData("tackleTestApp_Source", {
+    //             sourceData: this.appData["tackle-testapp-git"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.manageCredentials(sourceCredential.name, null);
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed", 30 * MIN);
+    // });
 
-    it("Analysis on tackle test app with ssh credentials", function () {
-        // Automate bug https://issues.redhat.com/browse/TACKLE-707
-        const scCredsKey = new CredentialsSourceControlKey(
-            data.getRandomCredentialsData(
-                CredentialType.sourceControl,
-                UserCredentials.sourcePrivateKey
-            )
-        );
-        scCredsKey.create();
-        const application = new Analysis(
-            getRandomApplicationData("tackleTestApp_sshCreds", {
-                sourceData: this.appData["tackle-testapp-ssh"],
-            }),
-            getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.manageCredentials(scCredsKey.name, null);
-        application.analyze();
-        application.verifyAnalysisStatus("Completed");
-    });
+    // it("Analysis on tackle test app with ssh credentials", function () {
+    //     // Automate bug https://issues.redhat.com/browse/TACKLE-707
+    //     const scCredsKey = new CredentialsSourceControlKey(
+    //         data.getRandomCredentialsData(
+    //             CredentialType.sourceControl,
+    //             UserCredentials.sourcePrivateKey
+    //         )
+    //     );
+    //     scCredsKey.create();
+    //     const application = new Analysis(
+    //         getRandomApplicationData("tackleTestApp_sshCreds", {
+    //             sourceData: this.appData["tackle-testapp-ssh"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.manageCredentials(scCredsKey.name, null);
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed");
+    // });
 
-    it("Analysis for known Open Source libraries on tackleTest app", function () {
-        // Source code analysis require both source and maven credentials
+    it("Analysis for known Open Source libraries on tackleTest app with default source and manually set maven credentials", function () {
+        // Source code analysis require both source and maven credentials, but src is set as default and maven is manually set
         const application = new Analysis(
             getRandomApplicationData("tackleTestApp_Source+knownLibraries", {
                 sourceData: this.appData["tackle-testapp-git"],
@@ -224,204 +224,204 @@ describe(["@tier2"], "Source Analysis", () => {
         application.create();
         applicationsList.push(application);
         cy.wait("@getApplication");
-        application.manageCredentials(sourceCredential.name, mavenCredential.name);
-        application.analyze();
-        application.verifyAnalysisStatus("Completed", 30 * MIN);
-    });
-
-    it("Automated tagging using Source Analysis on tackle testapp", function () {
-        // Automates Polarion MTA-208
-        const application = new Analysis(
-            getRandomApplicationData("tackleTestApp_Source_autoTagging", {
-                sourceData: this.appData["tackle-testapp-git"],
-            }),
-            getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.manageCredentials(sourceCredential.name, null);
-        application.analyze();
-        application.verifyAnalysisStatus("Completed");
-        application.applicationDetailsTab("Tags");
-        application.tagAndCategoryExists(
-            this.analysisData["analysis_for_enableTagging"]["techTags"]
-        );
-        application.closeApplicationDetails();
-    });
-
-    it("Bug MTA-3418: Disable Automated tagging using Source Analysis on bookServer app", function () {
-        // Automates Polarion MTA-307
-        const application = new Analysis(
-            getRandomApplicationData("bookserverApp_Disable_autoTagging", {
-                sourceData: this.appData["bookserver-app"],
-            }),
-            getRandomAnalysisData(this.analysisData["analysis_for_disableTagging"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.analyze();
-        application.verifyAnalysisStatus("Completed");
-        application.verifyEffort(this.analysisData["analysis_for_disableTagging"]["effort"]);
-        application.applicationDetailsTab("Tags");
-        cy.get("h2", { timeout: 5 * SEC }).should("contain", "No tags available");
-    });
-
-    it("Analysis for Konveyor example1 application", function () {
-        // Automates https://github.com/konveyor/example-applications/tree/main/example-1
-        const application = new Analysis(
-            getRandomApplicationData("Example 1", {
-                sourceData: this.appData["konveyor-exampleapp"],
-            }),
-            getRandomAnalysisData(this.analysisData["analysis_on_example-1-app"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.analyze();
-        application.verifyAnalysisStatus("Completed");
-        // Polarion TC 406
-        application.verifyEffort(this.analysisData["analysis_on_example-1-app"]["effort"]);
-    });
-
-    it("JWS6 target Source + deps analysis on tackletest app", function () {
-        // Source code analysis require both source and maven credentials
-        const application = new Analysis(
-            getRandomApplicationData("tackleTestApp_Source+dependencies_jws6", {
-                sourceData: this.appData["tackle-testapp-git"],
-            }),
-            getRandomAnalysisData(this.analysisData["jws6_source+dep_analysis_on_tackletestapp"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.manageCredentials(sourceCredential.name, mavenCredential.name);
-        application.analyze();
-        application.verifyAnalysisStatus("Completed");
-    });
-
-    it("Bug MTA-4412: Bug MTA-5212  Openjdk17 Source + dependencies analysis on tackletest app", function () {
-        const application = new Analysis(
-            getRandomApplicationData("tackleTestApp_Source+dependencies_openjdk17", {
-                sourceData: this.appData["tackle-testapp-git"],
-            }),
-            getRandomAnalysisData(
-                this.analysisData["openJDK17_source+dep_analysis_on_tackletestapp"]
-            )
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.manageCredentials(sourceCredential.name, mavenCredential.name);
-        application.analyze();
-        application.verifyAnalysisStatus("Completed");
-        application.verifyEffort(
-            this.analysisData["openJDK17_source+dep_analysis_on_tackletestapp"]["effort"]
-        );
-    });
-
-    it("OpenJDK21 Source + dependencies analysis on daytrader app", function () {
-        const application = new Analysis(
-            getRandomApplicationData("dayTraderApp_Source+dependencies_openjdk21", {
-                sourceData: this.appData["daytrader-app"],
-            }),
-            getRandomAnalysisData(this.analysisData["openJDK21_source+dep_analysis_on_dayTrader"])
-        );
-        application.create();
-        applicationsList.push(application);
-        cy.wait("@getApplication");
-        application.analyze();
-        application.verifyAnalysisStatus("Completed", 30 * MIN);
-        application.verifyEffort(
-            this.analysisData["openJDK21_source+dep_analysis_on_dayTrader"]["effort"]
-        );
-    });
-
-    // Automates customer bug MTA-1785
-    it("JDK<11 Source + dependencies analysis on tackle app public", function () {
-        const application = new Analysis(
-            getRandomApplicationData("tackle testapp public jdk 9", {
-                sourceData: this.appData["tackle-testapp-public-jdk9"],
-            }),
-            getRandomAnalysisData(this.analysisData["jdk9_source_dep_analysis_on_tackletestapp"])
-        );
-        application.create();
         application.manageCredentials(null, mavenCredential.name);
-        applicationsList.push(application);
-        cy.wait("@getApplication");
         application.analyze();
-        application.verifyAnalysisStatus(AnalysisStatuses.completed);
+        application.verifyAnalysisStatus("Completed", 30 * MIN);
     });
 
-    // Automates bug MTA-3422
-    it("4 targets source analysis on tackle app public", function () {
-        const application = new Analysis(
-            getRandomApplicationData("tackle-public-4-targets", {
-                sourceData: this.appData["tackle-testapp-public"],
-            }),
-            getRandomAnalysisData(this.analysisData["tackle-testapp-public-4-targets"])
-        );
-        application.create();
-        applicationsList.push(application);
-        application.analyze();
-        application.verifyAnalysisStatus("Completed");
-        application.verifyEffort(this.analysisData["tackle-testapp-public-4-targets"]["effort"]);
-    });
+    // it("Automated tagging using Source Analysis on tackle testapp", function () {
+    //     // Automates Polarion MTA-208
+    //     const application = new Analysis(
+    //         getRandomApplicationData("tackleTestApp_Source_autoTagging", {
+    //             sourceData: this.appData["tackle-testapp-git"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.manageCredentials(sourceCredential.name, null);
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed");
+    //     application.applicationDetailsTab("Tags");
+    //     application.tagAndCategoryExists(
+    //         this.analysisData["analysis_for_enableTagging"]["techTags"]
+    //     );
+    //     application.closeApplicationDetails();
+    // });
 
-    // Automates customer bug MTA-2973
-    it("Source analysis on tackle app public with custom rule", function () {
-        for (let i = 0; i < 2; i++) {
-            const application = new Analysis(
-                getRandomApplicationData("tackle-public-customRule", {
-                    sourceData: this.appData["tackle-testapp-public"],
-                }),
-                getRandomAnalysisData(this.analysisData["tackle-testapp-public-customRule"])
-            );
-            applicationsList.push(application);
-        }
+    // it("Bug MTA-3418: Disable Automated tagging using Source Analysis on bookServer app", function () {
+    //     // Automates Polarion MTA-307
+    //     const application = new Analysis(
+    //         getRandomApplicationData("bookserverApp_Disable_autoTagging", {
+    //             sourceData: this.appData["bookserver-app"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["analysis_for_disableTagging"])
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed");
+    //     application.verifyEffort(this.analysisData["analysis_for_disableTagging"]["effort"]);
+    //     application.applicationDetailsTab("Tags");
+    //     cy.get("h2", { timeout: 5 * SEC }).should("contain", "No tags available");
+    // });
 
-        // Analyze an application
-        const analyzeApplication = (application, credentials) => {
-            application.create();
-            if (credentials) application.manageCredentials(null, credentials.name);
-            application.analyze();
-            application.verifyAnalysisStatus("Completed");
-            application.validateIssues(
-                this.analysisData["tackle-testapp-public-customRule"]["issues"]
-            );
-        };
+    // it("Analysis for Konveyor example1 application", function () {
+    //     // Automates https://github.com/konveyor/example-applications/tree/main/example-1
+    //     const application = new Analysis(
+    //         getRandomApplicationData("Example 1", {
+    //             sourceData: this.appData["konveyor-exampleapp"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["analysis_on_example-1-app"])
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed");
+    //     // Polarion TC 406
+    //     application.verifyEffort(this.analysisData["analysis_on_example-1-app"]["effort"]);
+    // });
 
-        // Analyze application with Maven credentials
-        analyzeApplication(applicationsList[0], mavenCredential);
+    // it("JWS6 target Source + deps analysis on tackletest app", function () {
+    //     // Source code analysis require both source and maven credentials
+    //     const application = new Analysis(
+    //         getRandomApplicationData("tackleTestApp_Source+dependencies_jws6", {
+    //             sourceData: this.appData["tackle-testapp-git"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["jws6_source+dep_analysis_on_tackletestapp"])
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.manageCredentials(sourceCredential.name, mavenCredential.name);
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed");
+    // });
 
-        // Analyze application without Maven credentials
-        analyzeApplication(applicationsList[1], null);
-    });
+    // it("Bug MTA-4412: Bug MTA-5212  Openjdk17 Source + dependencies analysis on tackletest app", function () {
+    //     const application = new Analysis(
+    //         getRandomApplicationData("tackleTestApp_Source+dependencies_openjdk17", {
+    //             sourceData: this.appData["tackle-testapp-git"],
+    //         }),
+    //         getRandomAnalysisData(
+    //             this.analysisData["openJDK17_source+dep_analysis_on_tackletestapp"]
+    //         )
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.manageCredentials(sourceCredential.name, mavenCredential.name);
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed");
+    //     application.verifyEffort(
+    //         this.analysisData["openJDK17_source+dep_analysis_on_tackletestapp"]["effort"]
+    //     );
+    // });
 
-    it("Bug MTA-3701: Source analysis on tackle app with hash in Password", function () {
-        const application = new Analysis(
-            getRandomApplicationData("tackleTestApp_Source", {
-                sourceData: this.appData["tackle-testapp-git"],
-            }),
-            getRandomAnalysisData(this.analysisData["tackleTestApp_Source"])
-        );
+    // it("OpenJDK21 Source + dependencies analysis on daytrader app", function () {
+    //     const application = new Analysis(
+    //         getRandomApplicationData("dayTraderApp_Source+dependencies_openjdk21", {
+    //             sourceData: this.appData["daytrader-app"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["openJDK21_source+dep_analysis_on_dayTrader"])
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed", 30 * MIN);
+    //     application.verifyEffort(
+    //         this.analysisData["openJDK21_source+dep_analysis_on_dayTrader"]["effort"]
+    //     );
+    // });
 
-        // Analysis application with source credential created with hash
-        application.create();
-        application.manageCredentials(sourceCredentialWithHash.name);
-        applicationsList.push(application);
-        application.analyze();
-        application.verifyAnalysisStatus("Completed");
-    });
+    // // Automates customer bug MTA-1785
+    // it("JDK<11 Source + dependencies analysis on tackle app public", function () {
+    //     const application = new Analysis(
+    //         getRandomApplicationData("tackle testapp public jdk 9", {
+    //             sourceData: this.appData["tackle-testapp-public-jdk9"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["jdk9_source_dep_analysis_on_tackletestapp"])
+    //     );
+    //     application.create();
+    //     application.manageCredentials(null, mavenCredential.name);
+    //     applicationsList.push(application);
+    //     cy.wait("@getApplication");
+    //     application.analyze();
+    //     application.verifyAnalysisStatus(AnalysisStatuses.completed);
+    // });
 
-    after("Perform test data clean up", function () {
-        deleteByList(applicationsList);
-        sourceCredential.delete();
-        defaultSourceCredential.delete();
-        sourceCredentialWithHash.delete();
-        mavenCredential.delete();
-        defaultMavenCredential.delete();
-        writeMavenSettingsFile(data.getRandomWord(5), data.getRandomWord(5));
-    });
+    // // Automates bug MTA-3422
+    // it("4 targets source analysis on tackle app public", function () {
+    //     const application = new Analysis(
+    //         getRandomApplicationData("tackle-public-4-targets", {
+    //             sourceData: this.appData["tackle-testapp-public"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["tackle-testapp-public-4-targets"])
+    //     );
+    //     application.create();
+    //     applicationsList.push(application);
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed");
+    //     application.verifyEffort(this.analysisData["tackle-testapp-public-4-targets"]["effort"]);
+    // });
+
+    // // Automates customer bug MTA-2973
+    // it("Source analysis on tackle app public with custom rule", function () {
+    //     for (let i = 0; i < 2; i++) {
+    //         const application = new Analysis(
+    //             getRandomApplicationData("tackle-public-customRule", {
+    //                 sourceData: this.appData["tackle-testapp-public"],
+    //             }),
+    //             getRandomAnalysisData(this.analysisData["tackle-testapp-public-customRule"])
+    //         );
+    //         applicationsList.push(application);
+    //     }
+
+    //     // Analyze an application
+    //     const analyzeApplication = (application, credentials) => {
+    //         application.create();
+    //         if (credentials) application.manageCredentials(null, credentials.name);
+    //         application.analyze();
+    //         application.verifyAnalysisStatus("Completed");
+    //         application.validateIssues(
+    //             this.analysisData["tackle-testapp-public-customRule"]["issues"]
+    //         );
+    //     };
+
+    //     // Analyze application with Maven credentials
+    //     analyzeApplication(applicationsList[0], mavenCredential);
+
+    //     // Analyze application without Maven credentials
+    //     analyzeApplication(applicationsList[1], null);
+    // });
+
+    // it("Bug MTA-3701: Source analysis on tackle app with hash in Password", function () {
+    //     const application = new Analysis(
+    //         getRandomApplicationData("tackleTestApp_Source", {
+    //             sourceData: this.appData["tackle-testapp-git"],
+    //         }),
+    //         getRandomAnalysisData(this.analysisData["tackleTestApp_Source"])
+    //     );
+
+    //     // Analysis application with source credential created with hash
+    //     application.create();
+    //     application.manageCredentials(sourceCredentialWithHash.name);
+    //     applicationsList.push(application);
+    //     application.analyze();
+    //     application.verifyAnalysisStatus("Completed");
+    // });
+
+    // after("Perform test data clean up", function () {
+    //     deleteByList(applicationsList);
+    //     sourceCredential.delete();
+    //     defaultSourceCredential.delete();
+    //     sourceCredentialWithHash.delete();
+    //     mavenCredential.delete();
+    //     defaultMavenCredential.delete();
+    //     writeMavenSettingsFile(data.getRandomWord(5), data.getRandomWord(5));
+    // });
 });

--- a/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
@@ -108,110 +108,110 @@ describe(["@tier2"], "Source Analysis", () => {
         cy.visit("/");
     });
 
-    // it(
-    //     ["@tier1"],
-    //     "Source + dependencies analysis on tackletest app with default credentials",
-    //     function () {
-    //         // Source code analysis require both source and maven credentials
-    //         const application = new Analysis(
-    //             getRandomApplicationData("tackleTestApp_Source+dependencies", {
-    //                 sourceData: this.appData["tackle-testapp-git"],
-    //             }),
-    //             getRandomAnalysisData(this.analysisData["source+dep_analysis_on_tackletestapp"])
-    //         );
-    //         application.create();
-    //         applicationsList.push(application);
-    //         cy.wait("@getApplication");
-    //         application.analyze();
-    //         application.verifyAnalysisStatus("Completed");
-    //         application.verifyEffort(
-    //             this.analysisData["source+dep_analysis_on_tackletestapp"]["effort"]
-    //         );
-    //     }
-    // );
+    it(
+        ["@tier1"],
+        "Source + dependencies analysis on tackletest app with default credentials",
+        function () {
+            // Source code analysis require both source and maven credentials
+            const application = new Analysis(
+                getRandomApplicationData("tackleTestApp_Source+dependencies", {
+                    sourceData: this.appData["tackle-testapp-git"],
+                }),
+                getRandomAnalysisData(this.analysisData["source+dep_analysis_on_tackletestapp"])
+            );
+            application.create();
+            applicationsList.push(application);
+            cy.wait("@getApplication");
+            application.analyze();
+            application.verifyAnalysisStatus("Completed");
+            application.verifyEffort(
+                this.analysisData["source+dep_analysis_on_tackletestapp"]["effort"]
+            );
+        }
+    );
 
-    // it("Source + dependencies analysis on daytrader app", function () {
-    //     // Automate bug https://issues.redhat.com/browse/TACKLE-721
-    //     const application = new Analysis(
-    //         getRandomApplicationData("dayTraderApp_Source+dependencies", {
-    //             sourceData: this.appData["daytrader-app"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["source+dep_analysis_on_daytrader-app"])
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.analyze();
-    //     // Daytrader app take more than 20 min to analyze
-    //     application.verifyAnalysisStatus("Completed", 30 * MIN);
-    //     application.verifyEffort(
-    //         this.analysisData["source+dep_analysis_on_daytrader-app"]["effort"]
-    //     );
-    //     application.validateIssues(
-    //         this.analysisData["source+dep_analysis_on_daytrader-app"]["issues"]
-    //     );
-    //     // Automate bug https://issues.redhat.com/browse/MTA-2006
-    //     this.analysisData["source+dep_analysis_on_daytrader-app"]["issues"].forEach(
-    //         (currentIssue: AppIssue) => {
-    //             application.validateAffected(currentIssue);
-    //         }
-    //     );
-    // });
+    it("Source + dependencies analysis on daytrader app", function () {
+        // Automate bug https://issues.redhat.com/browse/TACKLE-721
+        const application = new Analysis(
+            getRandomApplicationData("dayTraderApp_Source+dependencies", {
+                sourceData: this.appData["daytrader-app"],
+            }),
+            getRandomAnalysisData(this.analysisData["source+dep_analysis_on_daytrader-app"])
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.analyze();
+        // Daytrader app take more than 20 min to analyze
+        application.verifyAnalysisStatus("Completed", 30 * MIN);
+        application.verifyEffort(
+            this.analysisData["source+dep_analysis_on_daytrader-app"]["effort"]
+        );
+        application.validateIssues(
+            this.analysisData["source+dep_analysis_on_daytrader-app"]["issues"]
+        );
+        // Automate bug https://issues.redhat.com/browse/MTA-2006
+        this.analysisData["source+dep_analysis_on_daytrader-app"]["issues"].forEach(
+            (currentIssue: AppIssue) => {
+                application.validateAffected(currentIssue);
+            }
+        );
+    });
 
-    // it("Analysis on daytrader app with maven credentials", function () {
-    //     // Automate bug https://issues.redhat.com/browse/TACKLE-751
-    //     const application = new Analysis(
-    //         getRandomApplicationData("dayTraderApp_MavenCreds", {
-    //             sourceData: this.appData["daytrader-app"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["source+dep_analysis_on_daytrader-app"])
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.manageCredentials(null, mavenCredential.name);
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed");
-    // });
+    it("Analysis on daytrader app with maven credentials", function () {
+        // Automate bug https://issues.redhat.com/browse/TACKLE-751
+        const application = new Analysis(
+            getRandomApplicationData("dayTraderApp_MavenCreds", {
+                sourceData: this.appData["daytrader-app"],
+            }),
+            getRandomAnalysisData(this.analysisData["source+dep_analysis_on_daytrader-app"])
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.manageCredentials(null, mavenCredential.name);
+        application.analyze();
+        application.verifyAnalysisStatus("Completed");
+    });
 
-    // it(["@tier1"], "Source Analysis on tackle testapp", function () {
-    //     // For tackle test app source credentials are required.
-    //     const application = new Analysis(
-    //         getRandomApplicationData("tackleTestApp_Source", {
-    //             sourceData: this.appData["tackle-testapp-git"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.manageCredentials(sourceCredential.name, null);
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed", 30 * MIN);
-    // });
+    it(["@tier1"], "Source Analysis on tackle testapp", function () {
+        // For tackle test app source credentials are required.
+        const application = new Analysis(
+            getRandomApplicationData("tackleTestApp_Source", {
+                sourceData: this.appData["tackle-testapp-git"],
+            }),
+            getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.manageCredentials(sourceCredential.name, null);
+        application.analyze();
+        application.verifyAnalysisStatus("Completed", 30 * MIN);
+    });
 
-    // it("Analysis on tackle test app with ssh credentials", function () {
-    //     // Automate bug https://issues.redhat.com/browse/TACKLE-707
-    //     const scCredsKey = new CredentialsSourceControlKey(
-    //         data.getRandomCredentialsData(
-    //             CredentialType.sourceControl,
-    //             UserCredentials.sourcePrivateKey
-    //         )
-    //     );
-    //     scCredsKey.create();
-    //     const application = new Analysis(
-    //         getRandomApplicationData("tackleTestApp_sshCreds", {
-    //             sourceData: this.appData["tackle-testapp-ssh"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.manageCredentials(scCredsKey.name, null);
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed");
-    // });
+    it("Analysis on tackle test app with ssh credentials", function () {
+        // Automate bug https://issues.redhat.com/browse/TACKLE-707
+        const scCredsKey = new CredentialsSourceControlKey(
+            data.getRandomCredentialsData(
+                CredentialType.sourceControl,
+                UserCredentials.sourcePrivateKey
+            )
+        );
+        scCredsKey.create();
+        const application = new Analysis(
+            getRandomApplicationData("tackleTestApp_sshCreds", {
+                sourceData: this.appData["tackle-testapp-ssh"],
+            }),
+            getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.manageCredentials(scCredsKey.name, null);
+        application.analyze();
+        application.verifyAnalysisStatus("Completed");
+    });
 
     it("Analysis for known Open Source libraries on tackleTest app with default source and manually set maven credentials", function () {
         // Source code analysis require both source and maven credentials, but src is set as default and maven is manually set
@@ -229,199 +229,199 @@ describe(["@tier2"], "Source Analysis", () => {
         application.verifyAnalysisStatus("Completed", 30 * MIN);
     });
 
-    // it("Automated tagging using Source Analysis on tackle testapp", function () {
-    //     // Automates Polarion MTA-208
-    //     const application = new Analysis(
-    //         getRandomApplicationData("tackleTestApp_Source_autoTagging", {
-    //             sourceData: this.appData["tackle-testapp-git"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.manageCredentials(sourceCredential.name, null);
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed");
-    //     application.applicationDetailsTab("Tags");
-    //     application.tagAndCategoryExists(
-    //         this.analysisData["analysis_for_enableTagging"]["techTags"]
-    //     );
-    //     application.closeApplicationDetails();
-    // });
+    it("Automated tagging using Source Analysis on tackle testapp", function () {
+        // Automates Polarion MTA-208
+        const application = new Analysis(
+            getRandomApplicationData("tackleTestApp_Source_autoTagging", {
+                sourceData: this.appData["tackle-testapp-git"],
+            }),
+            getRandomAnalysisData(this.analysisData["analysis_for_enableTagging"])
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.manageCredentials(sourceCredential.name, null);
+        application.analyze();
+        application.verifyAnalysisStatus("Completed");
+        application.applicationDetailsTab("Tags");
+        application.tagAndCategoryExists(
+            this.analysisData["analysis_for_enableTagging"]["techTags"]
+        );
+        application.closeApplicationDetails();
+    });
 
-    // it("Bug MTA-3418: Disable Automated tagging using Source Analysis on bookServer app", function () {
-    //     // Automates Polarion MTA-307
-    //     const application = new Analysis(
-    //         getRandomApplicationData("bookserverApp_Disable_autoTagging", {
-    //             sourceData: this.appData["bookserver-app"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["analysis_for_disableTagging"])
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed");
-    //     application.verifyEffort(this.analysisData["analysis_for_disableTagging"]["effort"]);
-    //     application.applicationDetailsTab("Tags");
-    //     cy.get("h2", { timeout: 5 * SEC }).should("contain", "No tags available");
-    // });
+    it("Bug MTA-3418: Disable Automated tagging using Source Analysis on bookServer app", function () {
+        // Automates Polarion MTA-307
+        const application = new Analysis(
+            getRandomApplicationData("bookserverApp_Disable_autoTagging", {
+                sourceData: this.appData["bookserver-app"],
+            }),
+            getRandomAnalysisData(this.analysisData["analysis_for_disableTagging"])
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.analyze();
+        application.verifyAnalysisStatus("Completed");
+        application.verifyEffort(this.analysisData["analysis_for_disableTagging"]["effort"]);
+        application.applicationDetailsTab("Tags");
+        cy.get("h2", { timeout: 5 * SEC }).should("contain", "No tags available");
+    });
 
-    // it("Analysis for Konveyor example1 application", function () {
-    //     // Automates https://github.com/konveyor/example-applications/tree/main/example-1
-    //     const application = new Analysis(
-    //         getRandomApplicationData("Example 1", {
-    //             sourceData: this.appData["konveyor-exampleapp"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["analysis_on_example-1-app"])
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed");
-    //     // Polarion TC 406
-    //     application.verifyEffort(this.analysisData["analysis_on_example-1-app"]["effort"]);
-    // });
+    it("Analysis for Konveyor example1 application", function () {
+        // Automates https://github.com/konveyor/example-applications/tree/main/example-1
+        const application = new Analysis(
+            getRandomApplicationData("Example 1", {
+                sourceData: this.appData["konveyor-exampleapp"],
+            }),
+            getRandomAnalysisData(this.analysisData["analysis_on_example-1-app"])
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.analyze();
+        application.verifyAnalysisStatus("Completed");
+        // Polarion TC 406
+        application.verifyEffort(this.analysisData["analysis_on_example-1-app"]["effort"]);
+    });
 
-    // it("JWS6 target Source + deps analysis on tackletest app", function () {
-    //     // Source code analysis require both source and maven credentials
-    //     const application = new Analysis(
-    //         getRandomApplicationData("tackleTestApp_Source+dependencies_jws6", {
-    //             sourceData: this.appData["tackle-testapp-git"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["jws6_source+dep_analysis_on_tackletestapp"])
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.manageCredentials(sourceCredential.name, mavenCredential.name);
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed");
-    // });
+    it("JWS6 target Source + deps analysis on tackletest app", function () {
+        // Source code analysis require both source and maven credentials
+        const application = new Analysis(
+            getRandomApplicationData("tackleTestApp_Source+dependencies_jws6", {
+                sourceData: this.appData["tackle-testapp-git"],
+            }),
+            getRandomAnalysisData(this.analysisData["jws6_source+dep_analysis_on_tackletestapp"])
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.manageCredentials(sourceCredential.name, mavenCredential.name);
+        application.analyze();
+        application.verifyAnalysisStatus("Completed");
+    });
 
-    // it("Bug MTA-4412: Bug MTA-5212  Openjdk17 Source + dependencies analysis on tackletest app", function () {
-    //     const application = new Analysis(
-    //         getRandomApplicationData("tackleTestApp_Source+dependencies_openjdk17", {
-    //             sourceData: this.appData["tackle-testapp-git"],
-    //         }),
-    //         getRandomAnalysisData(
-    //             this.analysisData["openJDK17_source+dep_analysis_on_tackletestapp"]
-    //         )
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.manageCredentials(sourceCredential.name, mavenCredential.name);
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed");
-    //     application.verifyEffort(
-    //         this.analysisData["openJDK17_source+dep_analysis_on_tackletestapp"]["effort"]
-    //     );
-    // });
+    it("Bug MTA-4412: Bug MTA-5212  Openjdk17 Source + dependencies analysis on tackletest app", function () {
+        const application = new Analysis(
+            getRandomApplicationData("tackleTestApp_Source+dependencies_openjdk17", {
+                sourceData: this.appData["tackle-testapp-git"],
+            }),
+            getRandomAnalysisData(
+                this.analysisData["openJDK17_source+dep_analysis_on_tackletestapp"]
+            )
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.manageCredentials(sourceCredential.name, mavenCredential.name);
+        application.analyze();
+        application.verifyAnalysisStatus("Completed");
+        application.verifyEffort(
+            this.analysisData["openJDK17_source+dep_analysis_on_tackletestapp"]["effort"]
+        );
+    });
 
-    // it("OpenJDK21 Source + dependencies analysis on daytrader app", function () {
-    //     const application = new Analysis(
-    //         getRandomApplicationData("dayTraderApp_Source+dependencies_openjdk21", {
-    //             sourceData: this.appData["daytrader-app"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["openJDK21_source+dep_analysis_on_dayTrader"])
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed", 30 * MIN);
-    //     application.verifyEffort(
-    //         this.analysisData["openJDK21_source+dep_analysis_on_dayTrader"]["effort"]
-    //     );
-    // });
+    it("OpenJDK21 Source + dependencies analysis on daytrader app", function () {
+        const application = new Analysis(
+            getRandomApplicationData("dayTraderApp_Source+dependencies_openjdk21", {
+                sourceData: this.appData["daytrader-app"],
+            }),
+            getRandomAnalysisData(this.analysisData["openJDK21_source+dep_analysis_on_dayTrader"])
+        );
+        application.create();
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.analyze();
+        application.verifyAnalysisStatus("Completed", 30 * MIN);
+        application.verifyEffort(
+            this.analysisData["openJDK21_source+dep_analysis_on_dayTrader"]["effort"]
+        );
+    });
 
-    // // Automates customer bug MTA-1785
-    // it("JDK<11 Source + dependencies analysis on tackle app public", function () {
-    //     const application = new Analysis(
-    //         getRandomApplicationData("tackle testapp public jdk 9", {
-    //             sourceData: this.appData["tackle-testapp-public-jdk9"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["jdk9_source_dep_analysis_on_tackletestapp"])
-    //     );
-    //     application.create();
-    //     application.manageCredentials(null, mavenCredential.name);
-    //     applicationsList.push(application);
-    //     cy.wait("@getApplication");
-    //     application.analyze();
-    //     application.verifyAnalysisStatus(AnalysisStatuses.completed);
-    // });
+    // Automates customer bug MTA-1785
+    it("JDK<11 Source + dependencies analysis on tackle app public", function () {
+        const application = new Analysis(
+            getRandomApplicationData("tackle testapp public jdk 9", {
+                sourceData: this.appData["tackle-testapp-public-jdk9"],
+            }),
+            getRandomAnalysisData(this.analysisData["jdk9_source_dep_analysis_on_tackletestapp"])
+        );
+        application.create();
+        application.manageCredentials(null, mavenCredential.name);
+        applicationsList.push(application);
+        cy.wait("@getApplication");
+        application.analyze();
+        application.verifyAnalysisStatus(AnalysisStatuses.completed);
+    });
 
-    // // Automates bug MTA-3422
-    // it("4 targets source analysis on tackle app public", function () {
-    //     const application = new Analysis(
-    //         getRandomApplicationData("tackle-public-4-targets", {
-    //             sourceData: this.appData["tackle-testapp-public"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["tackle-testapp-public-4-targets"])
-    //     );
-    //     application.create();
-    //     applicationsList.push(application);
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed");
-    //     application.verifyEffort(this.analysisData["tackle-testapp-public-4-targets"]["effort"]);
-    // });
+    // Automates bug MTA-3422
+    it("4 targets source analysis on tackle app public", function () {
+        const application = new Analysis(
+            getRandomApplicationData("tackle-public-4-targets", {
+                sourceData: this.appData["tackle-testapp-public"],
+            }),
+            getRandomAnalysisData(this.analysisData["tackle-testapp-public-4-targets"])
+        );
+        application.create();
+        applicationsList.push(application);
+        application.analyze();
+        application.verifyAnalysisStatus("Completed");
+        application.verifyEffort(this.analysisData["tackle-testapp-public-4-targets"]["effort"]);
+    });
 
-    // // Automates customer bug MTA-2973
-    // it("Source analysis on tackle app public with custom rule", function () {
-    //     for (let i = 0; i < 2; i++) {
-    //         const application = new Analysis(
-    //             getRandomApplicationData("tackle-public-customRule", {
-    //                 sourceData: this.appData["tackle-testapp-public"],
-    //             }),
-    //             getRandomAnalysisData(this.analysisData["tackle-testapp-public-customRule"])
-    //         );
-    //         applicationsList.push(application);
-    //     }
+    // Automates customer bug MTA-2973
+    it("Source analysis on tackle app public with custom rule", function () {
+        for (let i = 0; i < 2; i++) {
+            const application = new Analysis(
+                getRandomApplicationData("tackle-public-customRule", {
+                    sourceData: this.appData["tackle-testapp-public"],
+                }),
+                getRandomAnalysisData(this.analysisData["tackle-testapp-public-customRule"])
+            );
+            applicationsList.push(application);
+        }
 
-    //     // Analyze an application
-    //     const analyzeApplication = (application, credentials) => {
-    //         application.create();
-    //         if (credentials) application.manageCredentials(null, credentials.name);
-    //         application.analyze();
-    //         application.verifyAnalysisStatus("Completed");
-    //         application.validateIssues(
-    //             this.analysisData["tackle-testapp-public-customRule"]["issues"]
-    //         );
-    //     };
+        // Analyze an application
+        const analyzeApplication = (application, credentials) => {
+            application.create();
+            if (credentials) application.manageCredentials(null, credentials.name);
+            application.analyze();
+            application.verifyAnalysisStatus("Completed");
+            application.validateIssues(
+                this.analysisData["tackle-testapp-public-customRule"]["issues"]
+            );
+        };
 
-    //     // Analyze application with Maven credentials
-    //     analyzeApplication(applicationsList[0], mavenCredential);
+        // Analyze application with Maven credentials
+        analyzeApplication(applicationsList[0], mavenCredential);
 
-    //     // Analyze application without Maven credentials
-    //     analyzeApplication(applicationsList[1], null);
-    // });
+        // Analyze application without Maven credentials
+        analyzeApplication(applicationsList[1], null);
+    });
 
-    // it("Bug MTA-3701: Source analysis on tackle app with hash in Password", function () {
-    //     const application = new Analysis(
-    //         getRandomApplicationData("tackleTestApp_Source", {
-    //             sourceData: this.appData["tackle-testapp-git"],
-    //         }),
-    //         getRandomAnalysisData(this.analysisData["tackleTestApp_Source"])
-    //     );
+    it("Bug MTA-3701: Source analysis on tackle app with hash in Password", function () {
+        const application = new Analysis(
+            getRandomApplicationData("tackleTestApp_Source", {
+                sourceData: this.appData["tackle-testapp-git"],
+            }),
+            getRandomAnalysisData(this.analysisData["tackleTestApp_Source"])
+        );
 
-    //     // Analysis application with source credential created with hash
-    //     application.create();
-    //     application.manageCredentials(sourceCredentialWithHash.name);
-    //     applicationsList.push(application);
-    //     application.analyze();
-    //     application.verifyAnalysisStatus("Completed");
-    // });
+        // Analysis application with source credential created with hash
+        application.create();
+        application.manageCredentials(sourceCredentialWithHash.name);
+        applicationsList.push(application);
+        application.analyze();
+        application.verifyAnalysisStatus("Completed");
+    });
 
-    // after("Perform test data clean up", function () {
-    //     deleteByList(applicationsList);
-    //     sourceCredential.delete();
-    //     defaultSourceCredential.delete();
-    //     sourceCredentialWithHash.delete();
-    //     mavenCredential.delete();
-    //     defaultMavenCredential.delete();
-    //     writeMavenSettingsFile(data.getRandomWord(5), data.getRandomWord(5));
-    // });
+    after("Perform test data clean up", function () {
+        deleteByList(applicationsList);
+        sourceCredential.delete();
+        defaultSourceCredential.delete();
+        sourceCredentialWithHash.delete();
+        mavenCredential.delete();
+        defaultMavenCredential.delete();
+        writeMavenSettingsFile(data.getRandomWord(5), data.getRandomWord(5));
+    });
 });


### PR DESCRIPTION
Automates https://github.com/issues/assigned?issue=konveyor%7Ctackle-ui-tests%7C1612

## Test Run

[MTA 8.0.0-42](https://jenkins-csb-migrationqe-main.dno.corp.redhat.com/job/mta/job/mta-ui-tests-runner/5819/console)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Renamed a Source Analysis end-to-end test to reflect use of the default source credential with a manually provided Maven credential.
  * Adjusted the credentials flow in that test to use the default source credential.
  * Kept the existing create/wait/analyze/verify flow and timeouts; no user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->