### PR TITLE
[RFR] Add exception for monaco editor

### DIFF
--- a/cypress/e2e/tests/migration/reports-tab/reports.test.ts
+++ b/cypress/e2e/tests/migration/reports-tab/reports.test.ts
@@ -60,7 +60,7 @@ describe(["@tier3"], "Reports tests", () => {
         }
     });
 
-    it("Number of Application risk validation", function () {
+    it("Bug MTA-5883: Number of Application risk validation", function () {
         Reports.open();
         Reports.verifyRisk(
             highRiskApps,

--- a/cypress/e2e/tests/migration/reports-tab/reports.test.ts
+++ b/cypress/e2e/tests/migration/reports-tab/reports.test.ts
@@ -60,7 +60,7 @@ describe(["@tier3"], "Reports tests", () => {
         }
     });
 
-    it("Bug MTA-5883: Number of Application risk validation", function () {
+    it("Number of Application risk validation", function () {
         Reports.open();
         Reports.verifyRisk(
             highRiskApps,

--- a/cypress/support/e2e.ts
+++ b/cypress/support/e2e.ts
@@ -43,6 +43,12 @@ if (app && !app.document.head.querySelector("[data-hide-command-log-request]")) 
     app.document.head.appendChild(style);
 }
 
+Cypress.on("uncaught:exception", (err) => {
+    if (err.message.includes("Failed to execute 'importScripts'")) {
+        return false; // don't fail test
+    }
+});
+
 beforeEach(() => {
     // Disable for static report test as it need to open local files
     if (Cypress.spec.name === "static_report.test.ts") {


### PR DESCRIPTION
In one of the tests, we open the modal and then Cypress tries to query inside Monaco editor:
```
cy.get("div.monaco-scrollable-element.editor-scrollable.vs-dark")
    .invoke("text")
```
If the worker script fails to load , Monaco may throw an exception inside the web worker (importScripts failure). Cypress sees that uncaught exception and fails the test.

In this PR we are Catching and ignoring this particular exception in cypress/support/e2e.js:

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test stability by gracefully ignoring a specific non-critical browser error related to importScripts, reducing flaky failures in CI.
  * This change affects test execution only and does not alter application behavior or user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->