### PR TITLE
[JF][RFR] wait for file to be downloaded when exported

### DIFF
--- a/cypress/e2e/tests/administration/questionnaires/miscellaneous.test.ts
+++ b/cypress/e2e/tests/administration/questionnaires/miscellaneous.test.ts
@@ -89,8 +89,14 @@ describe(["@tier3"], "Miscellaneous Questionnaire tests", () => {
         const updatedFileName = "cloud-native-updated.yaml";
         const fixturesPath = "cypress/fixtures/" + updatedFileName;
 
+        cy.intercept({
+            method: "GET",
+            url: /\/hub\/questionnaires\/\d+$/,
+        }).as("fileDownload");
+
         AssessmentQuestionnaire.import(cloudNativePath);
         AssessmentQuestionnaire.export(cloudNative);
+        cy.wait("@fileDownload");
 
         cy.fsReadDir(cloudNativeDownloadPath).then((filesList) => {
             const matchedFiles = filesList
@@ -101,7 +107,6 @@ describe(["@tier3"], "Miscellaneous Questionnaire tests", () => {
                 }))
                 .filter((file) => !isNaN(file.number))
                 .sort((a, b) => b.number - a.number);
-
             const latestFileName = matchedFiles.length > 0 ? matchedFiles[0].file : null;
             const filePath = `${cloudNativeDownloadPath}/${latestFileName}`;
             cy.readFile(filePath).then((fileContent) => {
@@ -112,7 +117,6 @@ describe(["@tier3"], "Miscellaneous Questionnaire tests", () => {
                 cy.writeFile(fixturesPath, updatedContent);
             });
         });
-
         cy.readFile(fixturesPath).then(() => {
             AssessmentQuestionnaire.import(updatedFileName);
         });


### PR DESCRIPTION
Adding interception for file download and waiting for the response. This ensures the latest file is processed correctly before importing the updated content.

## Test Run

[MTA 8.0.0-42](https://jenkins-csb-migrationqe-main.dno.corp.redhat.com/job/mta/job/mta-ui-tests-runner/5833/console)

<!-- Add pull request description here -->

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of the questionnaire export download flow in end-to-end tests by explicitly waiting for the file download to complete before proceeding.
  * Minor formatting cleanups in related test code (no functional impact for users).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->