### PR TITLE
[RFR][Custom targets] Wait for @getTargets before cards validation

### DIFF
--- a/cypress/e2e/models/administration/custom-migration-targets/custom-migration-target.ts
+++ b/cypress/e2e/models/administration/custom-migration-targets/custom-migration-target.ts
@@ -65,22 +65,27 @@ export class CustomMigrationTarget {
      * @param forceReload
      */
     public static open(forceReload = false) {
-        if (forceReload) {
-            cy.visit(CustomMigrationTarget.fullUrl);
+        cy.intercept("GET", "/hub/targets*").as("getTargets");
+
+        const waitForTargets = () => {
+            cy.wait("@getTargets", { timeout: 30 * SEC });
             cy.get(CustomMigrationTargetView.card, { timeout: 30 * SEC }).should(
                 "contain",
                 "Containerization"
             );
+        };
+
+        if (forceReload) {
+            cy.visit(CustomMigrationTarget.fullUrl);
+            waitForTargets();
+            return;
         }
 
         cy.url().then(($url) => {
-            if ($url != CustomMigrationTarget.fullUrl) {
+            if ($url !== CustomMigrationTarget.fullUrl) {
                 selectUserPerspective("Administration");
                 clickByText(navMenu, customMigrationTargets);
-                cy.get(CustomMigrationTargetView.card, { timeout: 30 * SEC }).should(
-                    "contain",
-                    "Containerization"
-                );
+                waitForTargets();
             }
         });
     }

--- a/cypress/e2e/tests/administration/custom-migration-targets/crud.test.ts
+++ b/cypress/e2e/tests/administration/custom-migration-targets/crud.test.ts
@@ -87,7 +87,6 @@ describe(["@tier0", "@interop"], "Custom Migration Targets CRUD operations", () 
                 cy.intercept("DELETE", "/hub/targets*/*").as("deleteTarget");
 
                 CustomMigrationTarget.open(true);
-                cy.wait("@getTargets", { timeout: 30 * SEC });
             });
 
             it("Custom Migration Targets CRUD with rules uploaded manually", function () {


### PR DESCRIPTION
Resolves:

- https://issues.redhat.com/browse/MTA-6056
- https://issues.redhat.com/browse/MTA-6057
- https://issues.redhat.com/browse/MTA-6075

Jenkis run: https://jenkins-csb-migrationqe-main.dno.corp.redhat.com/job/mta/job/tackle-ui-tests-pr-tester/job/PR-1658/13/console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Improved end-to-end stability for Custom Migration Targets by synchronizing data loading before assertions.
  - Centralized readiness checks to reduce flakiness and improve run consistency.
  - Streamlined navigation handling and removed redundant waits to speed up test execution.
  - Ensured earlier initialization of network monitoring to capture relevant requests reliably.
  - Maintained existing verifications while simplifying setup steps for clearer, more maintainable test flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->