### PR TITLE
[TA][RFR] Added logic to check analysis statuses for missing, invalid, valid, invalid default credentials

### DIFF
--- a/cypress/e2e/models/administration/credentials/credentials.ts
+++ b/cypress/e2e/models/administration/credentials/credentials.ts
@@ -156,13 +156,21 @@ export class Credentials {
     }
 
     protected setAsDefaultViaActionsMenu(): void {
+        Credentials.openList();
         this.isDefault = true;
         clickItemInKebabMenu(this.name, setAsDefaultAction);
+        cy.get("body").then(($body) => {
+            if ($body.find(modalBoxBody).length > 0) {
+                click(confirmButton);
+            }
+        });
     }
 
     protected unsetAsDefaultViaActionsMenu(): void {
+        Credentials.openList();
         this.isDefault = false;
         clickItemInKebabMenu(this.name, unsetAsDefaultAction);
+        click(confirmButton);
     }
 
     /** Validates if description field contains same value as sent parameter

--- a/cypress/e2e/tests/administration/credentials/maven_crud.test.ts
+++ b/cypress/e2e/tests/administration/credentials/maven_crud.test.ts
@@ -16,10 +16,9 @@ limitations under the License.
 /// <reference types="cypress" />
 
 import { getRandomCredentialsData } from "../../../../utils/data_utils";
-import { click, deleteByList } from "../../../../utils/utils";
+import { deleteByList } from "../../../../utils/utils";
 import { CredentialsMaven } from "../../../models/administration/credentials/credentialsMaven";
 import { CredentialType } from "../../../types/constants";
-import { confirmButton } from "../../../views/common.view";
 
 describe(["@tier3"], "Validation of Maven Credentials", () => {
     let mavenCredentials: CredentialsMaven[] = [];
@@ -48,7 +47,6 @@ describe(["@tier3"], "Validation of Maven Credentials", () => {
         mavenCredentialsSetAsDefault.create();
         mavenCredentials.push(mavenCredentialsSetAsDefault);
         mavenCredentialsSetAsDefault.setAsDefaultViaActionsMenu();
-        click(confirmButton);
         mavenCredentialsSetAsDefault.verifyDefaultCredentialIcon();
     });
 
@@ -62,7 +60,6 @@ describe(["@tier3"], "Validation of Maven Credentials", () => {
         mavenCredentials.push(tempDefaultCred);
         tempDefaultCred.verifyDefaultCredentialIcon();
         tempDefaultCred.unsetAsDefaultViaActionsMenu();
-        click(confirmButton);
         tempDefaultCred.verifyDefaultCredentialIcon();
     });
 

--- a/cypress/e2e/tests/administration/credentials/sourcecontrol_crud.test.ts
+++ b/cypress/e2e/tests/administration/credentials/sourcecontrol_crud.test.ts
@@ -16,11 +16,10 @@ limitations under the License.
 /// <reference types="cypress" />
 
 import { getRandomCredentialsData } from "../../../../utils/data_utils";
-import { click, login } from "../../../../utils/utils";
+import { login } from "../../../../utils/utils";
 import { CredentialsSourceControlKey } from "../../../models/administration/credentials/credentialsSourceControlKey";
 import { CredentialsSourceControlUsername } from "../../../models/administration/credentials/credentialsSourceControlUsername";
 import { CredentialType, UserCredentials } from "../../../types/constants";
-import { confirmButton } from "../../../views/common.view";
 
 describe(["@tier2"], "Validation of Source Control Credentials", () => {
     let scCredsUsername: CredentialsSourceControlUsername;
@@ -88,7 +87,6 @@ describe(["@tier2"], "Validation of Source Control Credentials", () => {
         tempDefaultCred.create();
         tempDefaultCred.verifyDefaultCredentialIcon();
         tempDefaultCred.unsetAsDefaultViaActionsMenu();
-        click(confirmButton);
         tempDefaultCred.verifyDefaultCredentialIcon();
         tempDefaultCred.delete();
     });

--- a/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
@@ -36,7 +36,6 @@ import {
 } from "../../../../types/constants";
 let sourceCredential: CredentialsSourceControlUsername;
 let invalidSourceCredential: CredentialsSourceControlUsername;
-let sourceCredentialWithHash: CredentialsSourceControlUsername;
 let mavenCredential: CredentialsMaven;
 let applicationsList: Array<Analysis> = [];
 
@@ -64,17 +63,6 @@ describe(["@tier2"], "Source Analysis", () => {
             password: "invalidDefaultSourceCredential",
         });
         invalidSourceCredential.create();
-
-        // Create source Credentials with # in password
-        sourceCredentialWithHash = new CredentialsSourceControlUsername(
-            data.getRandomCredentialsData(
-                CredentialType.sourceControl,
-                UserCredentials.usernamePassword,
-                true
-            )
-        );
-        sourceCredentialWithHash.password = "#" + sourceCredentialWithHash.password;
-        sourceCredentialWithHash.create();
 
         // Create Maven credentials
         mavenCredential = new CredentialsMaven(
@@ -400,7 +388,6 @@ describe(["@tier2"], "Source Analysis", () => {
         deleteByList(applicationsList);
         sourceCredential.delete();
         invalidSourceCredential.delete();
-        sourceCredentialWithHash.delete();
         mavenCredential.delete();
         writeMavenSettingsFile(data.getRandomWord(5), data.getRandomWord(5));
     });

--- a/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
@@ -35,8 +35,7 @@ import {
     UserCredentials,
 } from "../../../../types/constants";
 let sourceCredential: CredentialsSourceControlUsername;
-let validDefaultSourceCredential: CredentialsSourceControlUsername;
-let invalidDefaultSourceCredential: CredentialsSourceControlUsername;
+let invalidSourceCredential: CredentialsSourceControlUsername;
 let sourceCredentialWithHash: CredentialsSourceControlUsername;
 let mavenCredential: CredentialsMaven;
 let applicationsList: Array<Analysis> = [];
@@ -56,26 +55,15 @@ describe(["@tier2"], "Source Analysis", () => {
         );
         sourceCredential.create();
 
-        // Create valid source Credentials
-        validDefaultSourceCredential = new CredentialsSourceControlUsername(
-            data.getRandomCredentialsData(
-                CredentialType.sourceControl,
-                UserCredentials.usernamePassword,
-                true,
-                null
-            )
-        );
-        validDefaultSourceCredential.create();
-
         // Create invalid source Credentials
-        invalidDefaultSourceCredential = new CredentialsSourceControlUsername({
+        invalidSourceCredential = new CredentialsSourceControlUsername({
             type: CredentialType.sourceControl,
             name: "invalidDefaultSourceCredential",
             description: "invalidDefaultSourceCredential",
             username: "invalidDefaultSourceCredential",
             password: "invalidDefaultSourceCredential",
         });
-        invalidDefaultSourceCredential.create();
+        invalidSourceCredential.create();
 
         // Create source Credentials with # in password
         sourceCredentialWithHash = new CredentialsSourceControlUsername(
@@ -129,13 +117,13 @@ describe(["@tier2"], "Source Analysis", () => {
             application.verifyAnalysisStatus(AnalysisStatuses.failed);
 
             // analyze with inValid default source creds and valid maven creds
-            invalidDefaultSourceCredential.setAsDefaultViaActionsMenu();
+            invalidSourceCredential.setAsDefaultViaActionsMenu();
             mavenCredential.setAsDefaultViaActionsMenu();
             application.analyze();
             application.verifyAnalysisStatus(AnalysisStatuses.failed);
 
             // analyze with valid default source and maven creds
-            validDefaultSourceCredential.setAsDefaultViaActionsMenu();
+            sourceCredential.setAsDefaultViaActionsMenu();
             application.analyze();
             application.verifyAnalysisStatus(AnalysisStatuses.completed);
             application.verifyEffort(
@@ -143,7 +131,7 @@ describe(["@tier2"], "Source Analysis", () => {
             );
 
             // analyze after removing valid default source and maven creds
-            validDefaultSourceCredential.unsetAsDefaultViaActionsMenu();
+            sourceCredential.unsetAsDefaultViaActionsMenu();
             mavenCredential.unsetAsDefaultViaActionsMenu();
             application.analyze();
             application.verifyAnalysisStatus(AnalysisStatuses.failed);
@@ -411,8 +399,7 @@ describe(["@tier2"], "Source Analysis", () => {
     after("Perform test data clean up", function () {
         deleteByList(applicationsList);
         sourceCredential.delete();
-        validDefaultSourceCredential.delete();
-        invalidDefaultSourceCredential.delete();
+        invalidSourceCredential.delete();
         sourceCredentialWithHash.delete();
         mavenCredential.delete();
         writeMavenSettingsFile(data.getRandomWord(5), data.getRandomWord(5));

--- a/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
@@ -39,7 +39,6 @@ let validDefaultSourceCredential: CredentialsSourceControlUsername;
 let invalidDefaultSourceCredential: CredentialsSourceControlUsername;
 let sourceCredentialWithHash: CredentialsSourceControlUsername;
 let mavenCredential: CredentialsMaven;
-let validDefaultMavenCredential: CredentialsMaven;
 let applicationsList: Array<Analysis> = [];
 
 describe(["@tier2"], "Source Analysis", () => {
@@ -57,7 +56,7 @@ describe(["@tier2"], "Source Analysis", () => {
         );
         sourceCredential.create();
 
-        // Create default source Credentials
+        // Create valid source Credentials
         validDefaultSourceCredential = new CredentialsSourceControlUsername(
             data.getRandomCredentialsData(
                 CredentialType.sourceControl,
@@ -68,7 +67,7 @@ describe(["@tier2"], "Source Analysis", () => {
         );
         validDefaultSourceCredential.create();
 
-        // Create invalid default source Credentials
+        // Create invalid source Credentials
         invalidDefaultSourceCredential = new CredentialsSourceControlUsername({
             type: CredentialType.sourceControl,
             name: "invalidDefaultSourceCredential",
@@ -94,12 +93,6 @@ describe(["@tier2"], "Source Analysis", () => {
             data.getRandomCredentialsData(CredentialType.maven, null, true)
         );
         mavenCredential.create();
-
-        // Create default Maven credentials
-        validDefaultMavenCredential = new CredentialsMaven(
-            data.getRandomCredentialsData(CredentialType.maven, null, true)
-        );
-        validDefaultMavenCredential.create();
     });
 
     beforeEach("Load data", function () {
@@ -135,24 +128,23 @@ describe(["@tier2"], "Source Analysis", () => {
             application.analyze();
             application.verifyAnalysisStatus(AnalysisStatuses.failed);
 
-            // analyze with inValid default source creds
+            // analyze with inValid default source creds and valid maven creds
             invalidDefaultSourceCredential.setAsDefaultViaActionsMenu();
+            mavenCredential.setAsDefaultViaActionsMenu();
             application.analyze();
             application.verifyAnalysisStatus(AnalysisStatuses.failed);
 
             // analyze with valid default source and maven creds
-            validDefaultMavenCredential.setAsDefaultViaActionsMenu();
             validDefaultSourceCredential.setAsDefaultViaActionsMenu();
             application.analyze();
             application.verifyAnalysisStatus(AnalysisStatuses.completed);
-
             application.verifyEffort(
                 this.analysisData["source+dep_analysis_on_tackletestapp"]["effort"]
             );
 
             // analyze after removing valid default source and maven creds
             validDefaultSourceCredential.unsetAsDefaultViaActionsMenu();
-            validDefaultMavenCredential.unsetAsDefaultViaActionsMenu();
+            mavenCredential.unsetAsDefaultViaActionsMenu();
             application.analyze();
             application.verifyAnalysisStatus(AnalysisStatuses.failed);
         }

--- a/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
+++ b/cypress/e2e/tests/migration/applicationinventory/analysis/source_analysis.test.ts
@@ -412,9 +412,9 @@ describe(["@tier2"], "Source Analysis", () => {
         deleteByList(applicationsList);
         sourceCredential.delete();
         validDefaultSourceCredential.delete();
+        invalidDefaultSourceCredential.delete();
         sourceCredentialWithHash.delete();
         mavenCredential.delete();
-        validDefaultMavenCredential.delete();
         writeMavenSettingsFile(data.getRandomWord(5), data.getRandomWord(5));
     });
 });


### PR DESCRIPTION
## Test Run
[MTA 8.0.0-55](https://jenkins-csb-migrationqe-main.dno.corp.redhat.com/job/mta/job/mta-ui-tests-runner/5868/console)

<!-- Add pull request description here -->

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Credential tests now ensure the credentials list is loaded and handle confirmation dialogs automatically.
  * Removed redundant manual confirmation steps from credential tests.
  * Expanded analysis tests to cover no-default, invalid-default, valid-default, and post-unset scenarios; assertions standardized to status enums.

* **Chores**
  * Test maintenance to reduce flakiness and improve reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->