### PR TITLE
[JF][RFR] Refactor AssessmentQuestionnaire navigation to use QuestionnaireBreadcrumb constant

### DIFF
--- a/cypress/e2e/models/administration/assessment_questionnaire/assessment_questionnaire.ts
+++ b/cypress/e2e/models/administration/assessment_questionnaire/assessment_questionnaire.ts
@@ -16,6 +16,7 @@ import { actionButton } from "../../../views/applicationinventory.view";
 import {
     confirmDeletion,
     importQuestionnaire,
+    QuestionnaireBreadcrumb,
     switchToggle,
 } from "../../../views/assessmentquestionnaire.view";
 import * as commonView from "../../../views/common.view";
@@ -188,7 +189,7 @@ export class AssessmentQuestionnaire {
     }
 
     static backToQuestionnaire(): void {
-        cy.get("button.pf-v5-c-button.pf-m-link").contains("Back to questionnaire").click();
+        cy.get(QuestionnaireBreadcrumb).contains("Assessment").click();
         cy.get(".pf-v5-c-content > h1").invoke("text").should("equal", "Assessment questionnaires");
     }
 

--- a/cypress/e2e/views/assessmentquestionnaire.view.ts
+++ b/cypress/e2e/views/assessmentquestionnaire.view.ts
@@ -6,3 +6,4 @@ export const switchToggle = ".pf-v5-c-switch__toggle";
 export const downloadYamlTemplate = "#download-yaml-template";
 export const ArchivedQuestionnaires = "Archived questionnaires";
 export const ArchivedQuestionnairesTableDataCell = 'td[data-label="Archived questionnaires"]';
+export const QuestionnaireBreadcrumb = ".pf-v5-c-breadcrumb__item";


### PR DESCRIPTION
## Test Run
[MTA 8.0.0-55](https://jenkins-csb-migrationqe-main.dno.corp.redhat.com/job/mta/job/mta-ui-tests-runner/5869/console)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated end-to-end navigation for assessment questionnaires to use the breadcrumb, improving test stability and alignment with current UI.
  * Introduced a reusable selector for breadcrumb items to streamline navigation steps in tests.
  * Preserved existing assertions to verify correct page titles after navigation.
  * No changes to user-facing behavior; these updates affect test reliability only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->