### PR TITLE
[RFR] Revert PR 1679

### DIFF
--- a/cypress/e2e/models/migration/applicationinventory/application.ts
+++ b/cypress/e2e/models/migration/applicationinventory/application.ts
@@ -159,7 +159,10 @@ export class Application {
         const itemsPerPage = 100;
         if (forceReload) {
             cy.visit(Application.fullUrl, { timeout: 35 * SEC }).then((_) => {
-                cy.get("h1", { timeout: 10 * SEC }).should("contain", applicationInventory);
+                // Bug MTA-3812 Application Inventory page takes long to load
+                // TODO: Wait of 10s to be reduced after above bug is fixed
+                cy.wait(10 * SEC);
+                cy.get("h1").should("contain", applicationInventory);
                 selectItemsPerPage(itemsPerPage);
             });
             return;


### PR DESCRIPTION
<!-- Add pull request description here -->
https://github.com/konveyor/tackle-ui-tests/pull/1679 was just a WIP PR to see if behavior had changed in MTA 8.0.0. 
The explicit wait is still required for automation to pass.

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved reliability of the Application Inventory end-to-end flow by introducing a brief wait before validating the header after a forced reload, reducing test flakiness in slower environments.
  * Streamlined the assertion timing to make tests more consistent across runs.
  * Added clarifying comments tied to a known issue to aid future maintenance.
  * No impact on product functionality or performance; changes are limited to test stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->