### PR TITLE
[RFR] Jenkins failure fix for sorting dependencies

### DIFF
--- a/cypress/e2e/tests/migration/dynamic-report/dependencies/sort.test.ts
+++ b/cypress/e2e/tests/migration/dynamic-report/dependencies/sort.test.ts
@@ -9,7 +9,7 @@ import { Dependencies } from "../../../../models/migration/dynamic-report/depend
 
 describe(["@tier3"], "Dependencies sort validations", function () {
     let application: Analysis;
-    const sortByList = ["Dependency name", "Labels", "Found in"];
+    const sortByList = ["Dependency name", "Language", "Found in"];
 
     before("Load data", function () {
         login();


### PR DESCRIPTION
<img width="1108" height="294" alt="image" src="https://github.com/user-attachments/assets/e453f7e5-c979-417d-80e3-88db3620223b" />


Labels cannot be sorted now . 
Language can be sorted .

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated automated validations for the Dependencies list sorting to align with current UI options, replacing “Labels” with “Language” alongside “Dependency name” and “Found in”.
  * Ensures end-to-end coverage remains accurate and reliable for migration dynamic report sorting behavior, improving test clarity and stability without impacting user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->