### PR TITLE
:bug: Update the selector for application inventory repo fields

### DIFF
--- a/cypress/e2e/views/applicationinventory.view.ts
+++ b/cypress/e2e/views/applicationinventory.view.ts
@@ -58,9 +58,9 @@ export const appSelectionButton = "button.pf-v5-c-menu-toggle__button";
 export const sideKebabMenu = "button[aria-label='Kebab toggle']";
 
 //Fields related to analysis - source mode
-export const sourceRepository = "input[name=sourceRepository]";
-export const branch = "input[name=branch]";
-export const rootPath = "input[name=rootPath]";
+export const sourceRepository = "input[id=sourceRepository]";
+export const branch = "input[id=branch]";
+export const rootPath = "input[id=rootPath]";
 
 //Fields related to analysis - binary mode
 export const group = "input[name=group]";


### PR DESCRIPTION
Due to changes in https://github.com/konveyor/tackle2-ui/pull/2663, the `sourceRepository`, `branch` and `rootPath` selectors are broken. Swapping the selectors to use `id` instead of `name` allows the id to remain stable even if the field's name changes.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Tests
  - Updated how end-to-end tests locate source analysis input fields by switching to ID-based selectors. This makes test runs more resilient to minor markup changes, reducing flakiness and false failures across environments. Users should not see any functional differences; existing features and workflows remain unchanged. This update improves test reliability and consistency, aiding faster troubleshooting and more dependable release validation without impacting the user interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->