### PR TITLE
Add a new function to match selector text

### DIFF
--- a/cypress/e2e/models/migration/applicationinventory/analysis.ts
+++ b/cypress/e2e/models/migration/applicationinventory/analysis.ts
@@ -24,7 +24,6 @@ import {
     clickWithinByText,
     doesExistSelector,
     inputText,
-    matchText,
     next,
     selectAnalysisMode,
     selectCheckBox,
@@ -32,12 +31,13 @@ import {
     sidedrawerTab,
     uploadApplications,
     uploadFile,
+    verifySelectorText,
 } from "../../../../utils/utils";
 import {
     AnalysisStatuses,
     analyzeAppButton,
     analyzeButton,
-    appInventoryKebab,
+    appInventoryKebab as kebab,
     button,
     clearAllFilters,
     Languages,
@@ -87,7 +87,7 @@ import {
     tabsPanel,
 } from "../../../views/analysis.view";
 import { bulkApplicationSelectionCheckBox } from "../../../views/applicationinventory.view";
-import { successAlertMessage } from "../../../views/common.view";
+import { actionMenuItem, successAlertMessage } from "../../../views/common.view";
 import { CustomMigrationTargetView } from "../../../views/custom-migration-target.view";
 import { Application } from "./application";
 
@@ -496,13 +496,26 @@ export class Analysis extends Application {
                 .within(() => {
                     clickWithin(kebabTopMenuButton, button);
                 });
-            matchText(appInventoryKebab.import, rbacRules["Top action menu"]["Import"]);
-            matchText(
-                appInventoryKebab.manageImports,
+            verifySelectorText(
+                kebab.import,
+                actionMenuItem,
+                rbacRules["Top action menu"]["Import"]
+            );
+            verifySelectorText(
+                kebab.manageImports,
+                actionMenuItem,
                 rbacRules["Top action menu"]["Manage application imports"]
             );
-            matchText("Manage credentials", rbacRules["Top action menu"]["Manage credentials"]);
-            matchText("Delete", rbacRules["Top action menu"]["Delete"]);
+            verifySelectorText(
+                kebab.manageCredentials,
+                actionMenuItem,
+                rbacRules["Top action menu"]["Manage credentials"]
+            );
+            verifySelectorText(
+                kebab.delete,
+                actionMenuItem,
+                rbacRules["Top action menu"]["Delete"]
+            );
         }
     }
 

--- a/cypress/e2e/types/constants.ts
+++ b/cypress/e2e/types/constants.ts
@@ -248,4 +248,6 @@ export enum TaskFilter {
 export enum appInventoryKebab {
     manageImports = "Manage application imports",
     import = "Import applications from CSV",
+    manageCredentials = "Manage credentials",
+    delete = "Delete",
 }

--- a/cypress/utils/utils.ts
+++ b/cypress/utils/utils.ts
@@ -1599,9 +1599,31 @@ export function doesExistButton(str: string, toBePresent: boolean): void {
     cy.contains(button, str).should(toBePresent ? "exist" : "not.exist");
 }
 
-export function matchText(str: string, toBePresent: boolean): void {
-    const escapedStr = str.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    cy.contains(new RegExp(`^${escapedStr}$`)).should(toBePresent ? "exist" : "not.exist");
+/**
+ * Verifies that at least one element matching the selector has the exact expected text.
+ * Unlike doesExistText which uses cy.contains() for partial/regex matching,
+ * this function performs exact text comparison on elements selected by a CSS selector.
+ *
+ * @param expectedText - The exact text to match (after trimming whitespace)
+ * @param selector - CSS selector to find elements
+ * @param shouldExist - true to assert text exists, false to assert it doesn't exist
+ */
+export function verifySelectorText(
+    expectedText: string,
+    selector: string,
+    shouldExist: boolean
+): void {
+    cy.get(selector).should(($elements) => {
+        const texts = Array.from($elements).map((el) => el.textContent?.trim() ?? "");
+        const matched = texts.includes(expectedText);
+
+        if (shouldExist) {
+            expect(matched, `Expected one of the elements to have exact text "${expectedText}"`).to
+                .be.true;
+        } else {
+            expect(matched, `Expected no element to have exact text "${expectedText}"`).to.be.false;
+        }
+    });
 }
 
 export function enableSwitch(selector: string): void {


### PR DESCRIPTION
<!-- Add pull request description here -->
In 8.0.1, the 'Import' top kebab menu option on the App Inventory page was replaced by 'Import applications from CSV'. Currently, only a sub text is matched , but the not the entire text. So, I've added a new function to match the exact text and updated the test to use the new function.

<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a reusable selector-text verification utility to improve assertion clarity, accuracy, and reliability across UI checks.
  * Updated top-action menu tests to use the new verifier and explicitly check menu entries: Import, Manage application imports, Manage credentials, and Delete, improving test stability and reducing false positives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->