### PR TITLE
[RFR] Making sure waitForTargets() runs on custom targets page

### DIFF
--- a/cypress/e2e/models/administration/custom-migration-targets/custom-migration-target.ts
+++ b/cypress/e2e/models/administration/custom-migration-targets/custom-migration-target.ts
@@ -68,6 +68,7 @@ export class CustomMigrationTarget {
         cy.intercept("GET", "/hub/targets*").as("getTargets");
 
         const waitForTargets = () => {
+            cy.get("h1").should("contain", customMigrationTargets);
             cy.wait("@getTargets", { timeout: 30 * SEC });
             cy.get(CustomMigrationTargetView.card, { timeout: 30 * SEC }).should(
                 "contain",

--- a/cypress/e2e/tests/administration/custom-migration-targets/crud.test.ts
+++ b/cypress/e2e/tests/administration/custom-migration-targets/crud.test.ts
@@ -86,7 +86,7 @@ describe(["@tier0", "@interop"], "Custom Migration Targets CRUD operations", () 
                 cy.intercept("PUT", "/hub/targets*/*").as("putTarget");
                 cy.intercept("DELETE", "/hub/targets*/*").as("deleteTarget");
 
-                CustomMigrationTarget.open(true);
+                CustomMigrationTarget.open();
             });
 
             it("Custom Migration Targets CRUD with rules uploaded manually", function () {


### PR DESCRIPTION
Relates to: https://issues.redhat.com/browse/MTA-6352
Jenkins run: https://jenkins-csb-migrationqe-main.dno.corp.redhat.com/job/mta/job/mta-ui-tests-runner/6171/console

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added a runtime check to ensure the custom migration targets page heading is displayed as expected.
  * Updated test setup to use a different navigation path during test initialization, aligning test behavior with current UI flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->