### PR TITLE
:test_tube: [RFR] Fix waves crud test

### DIFF
--- a/cypress/e2e/tests/migration/migration-waves/crud.test.ts
+++ b/cypress/e2e/tests/migration/migration-waves/crud.test.ts
@@ -165,7 +165,7 @@ describe(["@tier0", "interop"], "Migration Waves CRUD operations", () => {
         timeout = 10 * SEC
     ) => {
         cy.contains("td", wave.name)
-            .siblings(`td[data-label='${column}']`)
-            .should("contain", expectedCount, { timeout });
+            .siblings(`td[data-label='${column}']`, { timeout })
+            .should("contain", expectedCount);
     };
 });


### PR DESCRIPTION
<!-- Add pull request description here -->
Resolves [MTA-6427](https://issues.redhat.com/browse/MTA-6427), added some checks to ensure the test doesn't click faster that the app processes them.
<!--

Instructions while creating pull request.

- `Request review` from reviewers
    - sshveta
    - nachandr
    - igor
        - Click on `Reviewers` > Select reviewers from above options
- `Optional`
    - Add `RFR` [Ready for review] or `WIP` [Work in progress] in title as per your pull request progress

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved stability and reliability of migration wave end-to-end tests by switching to dynamic assertions that track actual application counts during delete flows. Removed unnecessary network-wait pauses, reducing flakiness and speeding up test feedback. Test helpers now allow configurable timeouts to better accommodate variable response times.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->